### PR TITLE
[feat] OBS表示をYouTube風スタイルに改善し、接続インジケーターを正常時非表示化

### DIFF
--- a/suiperchat_streamer_app/src-tauri/src/static/obs/index.html
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/index.html
@@ -8,12 +8,12 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>SUIperCHAT OBS Display</title>
-    <link rel="stylesheet" href="styles.css?v=1.0.4">
+    <link rel="stylesheet" href="styles.css?v=1.0.8">
     <style>
         body {
             background-color: transparent;
             color: #ffffff;
-            font-family: sans-serif;
+            font-family: "Noto Sans JP", sans-serif;
             overflow: hidden;
         }
 
@@ -98,7 +98,7 @@
             <!-- チャットメッセージとスーパーチャットメッセージはここに動的に追加されます -->
         </div>
     </div>
-    <script src="script.js?v=1.0.4"></script>
+    <script src="script.js?v=1.0.5"></script>
 </body>
 
 </html>

--- a/suiperchat_streamer_app/src-tauri/src/static/obs/index.html
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/index.html
@@ -34,6 +34,11 @@
             transition: opacity 0.3s;
         }
 
+        /* 接続済みの場合は透明にする */
+        .connection-indicator.connected {
+            opacity: 0;
+        }
+
         .connection-indicator:hover {
             opacity: 1;
         }

--- a/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
@@ -183,20 +183,37 @@ function displayChatMessage(data) {
  */
 function renderChatMessage(container, chatData) {
     // 新しいチャットメッセージ要素を作成 - YouTube風の構造
-    const chatElement = document.createElement('div');
-    chatElement.className = 'chat-message yt-live-chat-text-message-renderer';
-    
+    // 実際のYouTubeのHTML構造を参考に、yt-live-chat-text-message-renderer 要素を直接作成
+    const chatElement = document.createElement('yt-live-chat-text-message-renderer');
+    chatElement.className = 'style-scope yt-live-chat-item-list-renderer'; // Add necessary classes
+    chatElement.setAttribute('use-opacity-for-context-menu-visibility', '');
+    chatElement.setAttribute('modern', '');
+    // chatElement.id = `message-${chatData.timestamp}`; // Optional: Add a unique ID
+
     // メンバー機能は不要なので、すべて通常リスナー扱いにする
-    // author-type属性は設定しない
+    // author-type属性は設定しない (実際のHTMLにはauthor-type属性が存在)
+    // if (chatData.author_type) {
+    //     chatElement.setAttribute('author-type', chatData.author_type);
+    // }
     
-    // チャットメッセージの内容を設定 - YouTube風の構造
+    // チャットメッセージの内容を設定 - 実際のYouTubeのHTML構造を模倣
     chatElement.innerHTML = `
-        <yt-live-chat-author-chip class="yt-live-chat-text-message-renderer">
-            <span id="author-name">${escapeHtml(chatData.display_name)}</span>
-            <span id="chat-badges" class="yt-live-chat-author-chip"></span>
-        </yt-live-chat-author-chip>
-        <div id="message" class="yt-live-chat-text-message-renderer">${escapeHtml(chatData.message || '')}</div>
-        <span id="timestamp">${formatTimestamp(chatData.timestamp)}</span>
+        <yt-img-shadow id="author-photo" class="no-transition style-scope yt-live-chat-text-message-renderer" height="24" width="24" style="background-color: transparent;" loaded="">
+            <!-- ユーザーアイコンはデータに含まれていないため、srcは空またはプレースホルダー -->
+            <img id="img" draggable="false" class="style-scope yt-img-shadow" alt="" height="24" width="24" src="">
+        </yt-img-shadow>
+        <div id="content" class="style-scope yt-live-chat-text-message-renderer">
+            <span id="timestamp" class="style-scope yt-live-chat-text-message-renderer">${formatTimestamp(chatData.timestamp)}</span>
+            <yt-live-chat-author-chip class="style-scope yt-live-chat-text-message-renderer">
+                <span id="prepend-chat-badges" class="style-scope yt-live-chat-author-chip"></span>
+                <span id="author-name" dir="auto" class=" style-scope yt-live-chat-author-chip style-scope yt-live-chat-author-chip">${escapeHtml(chatData.display_name)}<span id="chip-badges" class="style-scope yt-live-chat-author-chip"></span></span>
+                <span id="chat-badges" class="style-scope yt-live-chat-author-chip"></span>
+            </yt-live-chat-author-chip>
+            <span id="message" dir="auto" class="style-scope yt-live-chat-text-message-renderer">${escapeHtml(chatData.message || '')}</span>
+        </div>
+        <!-- メニューやアクションボタンはOBS表示では不要なため省略 -->
+        <!-- <div id="menu" class="style-scope yt-live-chat-text-message-renderer">...</div> -->
+        <!-- <div id="inline-action-button-container" class="style-scope yt-live-chat-text-message-renderer">...</div> -->
     `;
     
     // ユーザー名とメッセージの検証を行い、コンソールに表示（デバッグ用）
@@ -351,4 +368,4 @@ function blinkConnectionIndicator() {
         dotElement.style.opacity = '';
         dotElement.style.transform = '';
     }, 300);
-} 
+}

--- a/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
@@ -1,6 +1,6 @@
 /**
  * SUIperCHAT OBS表示用JavaScriptファイル (v1.0.5)
- * 
+ *
  * WebSocketでスーパーチャットメッセージを受信し、OBS画面に表示する機能を実装します。
  * URLパラメータからWebSocketのアドレスを取得し、自動的に接続します。
  * YouTubeライクな表示スタイルに対応するためのDOM構造を生成します。
@@ -14,199 +14,203 @@ const maxMessages = 100; // 画面に表示する最大メッセージ数（増�
 const WS_PORT = 8082; // WebSocketサーバーのポート番号（固定）
 
 // DOMロード時の初期化処理
-document.addEventListener('DOMContentLoaded', () => {
-    console.log('SUIperCHAT OBS Display initialized v1.0.3');
-    initializeWebSocket();
+document.addEventListener("DOMContentLoaded", () => {
+	console.log("SUIperCHAT OBS Display initialized v1.0.3");
+	initializeWebSocket();
 });
 
 /**
  * WebSocket接続を初期化する
  */
 function initializeWebSocket() {
-    // URLからWebSocketパラメータを取得
-    // (現在は未使用だが、将来的にカスタムWebSocketアドレスを指定できるようにするため保持)
-    // const urlParams = new URLSearchParams(window.location.search);
-    
-    // 注意: OBSサーバーはポート8081で動いていますが、
-    // WebSocketサーバーは別のポート8082で動いています
-    // そのため、ハードコードされたアドレスを使用します
-    
-    // どのポートを使用しているかを明確に表示
-    console.log(`Using WebSocket port: ${WS_PORT}`);
-    
-    // 修正前: 現在のホストのWebSocketエンドポイントを使用
-    // const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    // const wsHost = window.location.host;
-    // const wsUrl = `${wsProtocol}//${wsHost}/ws`;
-    
-    // 修正後: 正しいWebSocketサーバーのアドレスを直接指定
-    const wsUrl = `ws://127.0.0.1:${WS_PORT}/ws`;
-    
-    console.log(`Connecting to WebSocket server: ${wsUrl}`);
-    
-    // 接続ステータスを更新
-    updateConnectionStatus('Connecting...', 'connecting');
-    
-    // 既存のWebSocket接続をクリーンアップ
-    if (socket) {
-        socket.close();
-    }
-    
-    // 新しいWebSocket接続を作成
-    socket = new WebSocket(wsUrl);
-    
-    // WebSocketイベントハンドラを設定
-    setupWebSocketEventHandlers();
+	// URLからWebSocketパラメータを取得
+	// (現在は未使用だが、将来的にカスタムWebSocketアドレスを指定できるようにするため保持)
+	// const urlParams = new URLSearchParams(window.location.search);
+
+	// 注意: OBSサーバーはポート8081で動いていますが、
+	// WebSocketサーバーは別のポート8082で動いています
+	// そのため、ハードコードされたアドレスを使用します
+
+	// どのポートを使用しているかを明確に表示
+	console.log(`Using WebSocket port: ${WS_PORT}`);
+
+	// 修正前: 現在のホストのWebSocketエンドポイントを使用
+	// const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+	// const wsHost = window.location.host;
+	// const wsUrl = `${wsProtocol}//${wsHost}/ws`;
+
+	// 修正後: 正しいWebSocketサーバーのアドレスを直接指定
+	const wsUrl = `ws://127.0.0.1:${WS_PORT}/ws`;
+
+	console.log(`Connecting to WebSocket server: ${wsUrl}`);
+
+	// 接続ステータスを更新
+	updateConnectionStatus("Connecting...", "connecting");
+
+	// 既存のWebSocket接続をクリーンアップ
+	if (socket) {
+		socket.close();
+	}
+
+	// 新しいWebSocket接続を作成
+	socket = new WebSocket(wsUrl);
+
+	// WebSocketイベントハンドラを設定
+	setupWebSocketEventHandlers();
 }
 
 /**
  * WebSocketのイベントハンドラをセットアップする
  */
 function setupWebSocketEventHandlers() {
-    // 接続が開いたとき
-    socket.addEventListener('open', () => {
-        console.log('WebSocket connection established');
-        // WebSocket接続状態を更新
-        updateConnectionStatus('Connected', 'connected');
-        // 再接続タイマーがある場合はクリア
-        if (reconnectTimeout) {
-            clearTimeout(reconnectTimeout);
-            reconnectTimeout = null;
-        }
-    });
+	// 接続が開いたとき
+	socket.addEventListener("open", () => {
+		console.log("WebSocket connection established");
+		// WebSocket接続状態を更新
+		updateConnectionStatus("Connected", "connected");
+		// 再接続タイマーがある場合はクリア
+		if (reconnectTimeout) {
+			clearTimeout(reconnectTimeout);
+			reconnectTimeout = null;
+		}
+	});
 
-    // メッセージを受信したとき
-    socket.addEventListener('message', (event) => {
-        console.log('WebSocket message received:', event.data);
-        try {
-            const data = JSON.parse(event.data);
-            
-            // メッセージ受信時には状態を変更せず、受信を視覚的に示す
-            blinkConnectionIndicator();
-            
-            // メッセージの種類に応じた処理
-            if (data.type === 'superchat') {
-                // スーパーチャットメッセージを表示
-                displaySuperchatMessage(data);
-            } else if (data.type === 'chat') {
-                // 通常チャットメッセージを表示
-                displayChatMessage(data);
-            } else {
-                // その他のメッセージタイプの場合
-                console.log('Unknown message type received:', data);
-            }
-        } catch (error) {
-            console.error('Error parsing WebSocket message:', error);
-        }
-    });
+	// メッセージを受信したとき
+	socket.addEventListener("message", (event) => {
+		console.log("WebSocket message received:", event.data);
+		try {
+			const data = JSON.parse(event.data);
 
-    // エラーが発生したとき
-    socket.addEventListener('error', (event) => {
-        console.error('WebSocket error:', event);
-        // WebSocket接続状態を更新
-        updateConnectionStatus('エラー', 'error');
-    });
+			// メッセージ受信時には状態を変更せず、受信を視覚的に示す
+			blinkConnectionIndicator();
 
-    // 接続が閉じたとき
-    socket.addEventListener('close', (event) => {
-        console.log(`WebSocket connection closed. Code: ${event.code}, Reason: ${event.reason}`);
-        // WebSocket接続状態を更新
-        updateConnectionStatus('Disconnected', 'error');
-        
-        // 自動再接続
-        if (!reconnectTimeout) {
-            reconnectTimeout = setTimeout(() => {
-                console.log('Attempting to reconnect...');
-                // WebSocket接続状態を更新
-                updateConnectionStatus('Reconnecting...', 'connecting');
-                initializeWebSocket();
-            }, reconnectInterval);
-        }
-    });
+			// メッセージの種類に応じた処理
+			if (data.type === "superchat") {
+				// スーパーチャットメッセージを表示
+				displaySuperchatMessage(data);
+			} else if (data.type === "chat") {
+				// 通常チャットメッセージを表示
+				displayChatMessage(data);
+			} else {
+				// その他のメッセージタイプの場合
+				console.log("Unknown message type received:", data);
+			}
+		} catch (error) {
+			console.error("Error parsing WebSocket message:", error);
+		}
+	});
+
+	// エラーが発生したとき
+	socket.addEventListener("error", (event) => {
+		console.error("WebSocket error:", event);
+		// WebSocket接続状態を更新
+		updateConnectionStatus("エラー", "error");
+	});
+
+	// 接続が閉じたとき
+	socket.addEventListener("close", (event) => {
+		console.log(
+			`WebSocket connection closed. Code: ${event.code}, Reason: ${event.reason}`,
+		);
+		// WebSocket接続状態を更新
+		updateConnectionStatus("Disconnected", "error");
+
+		// 自動再接続
+		if (!reconnectTimeout) {
+			reconnectTimeout = setTimeout(() => {
+				console.log("Attempting to reconnect...");
+				// WebSocket接続状態を更新
+				updateConnectionStatus("Reconnecting...", "connecting");
+				initializeWebSocket();
+			}, reconnectInterval);
+		}
+	});
 }
 
 /**
  * 接続状態を更新する
- * 
+ *
  * @param {string} status - 接続状態のテキスト
  * @param {string} statusClass - 接続状態のクラス名（connected, connecting, error）
  */
 function updateConnectionStatus(status, statusClass) {
-    const statusElement = document.getElementById('connection-status');
-    const dotElement = document.getElementById('status-dot');
-    const indicatorElement = document.querySelector('.connection-indicator');
-    
-    if (statusElement) {
-        statusElement.textContent = status;
-    }
-    
-    if (dotElement) {
-        // すべてのクラスをリセット
-        dotElement.classList.remove('connected', 'connecting', 'error');
-        // 新しいクラスを追加
-        dotElement.classList.add(statusClass);
-    }
-    
-    // 接続インジケーター全体にもクラスを適用
-    if (indicatorElement) {
-        // すべてのステータスクラスをリセット
-        indicatorElement.classList.remove('connected', 'connecting', 'error');
-        // 現在のステータスクラスを追加
-        indicatorElement.classList.add(statusClass);
-    }
+	const statusElement = document.getElementById("connection-status");
+	const dotElement = document.getElementById("status-dot");
+	const indicatorElement = document.querySelector(".connection-indicator");
+
+	if (statusElement) {
+		statusElement.textContent = status;
+	}
+
+	if (dotElement) {
+		// すべてのクラスをリセット
+		dotElement.classList.remove("connected", "connecting", "error");
+		// 新しいクラスを追加
+		dotElement.classList.add(statusClass);
+	}
+
+	// 接続インジケーター全体にもクラスを適用
+	if (indicatorElement) {
+		// すべてのステータスクラスをリセット
+		indicatorElement.classList.remove("connected", "connecting", "error");
+		// 現在のステータスクラスを追加
+		indicatorElement.classList.add(statusClass);
+	}
 }
 
 /**
  * 通常チャットメッセージを表示する
  * YouTube風のDOM構造を模倣して表示します
- * 
+ *
  * @param {Object} data - チャットデータ
  */
 function displayChatMessage(data) {
-    const container = document.getElementById('superchat-container');
-    
-    // データチェック - 必須項目がない場合はエラーログを出力
-    if (!data || !data.display_name) {
-        console.error('Invalid chat data received:', data);
-        // 元のデータは変更せず、表示用のデータを作成
-        const fallbackData = {
-            display_name: 'Unknown User', 
-            message: data?.message || 'No message content',
-            timestamp: Date.now()
-        };
-        
-        // 安全な表示用データを使用
-        renderChatMessage(container, fallbackData);
-        return;
-    }
-    
-    // 正常なデータの場合は表示処理を行う
-    renderChatMessage(container, data);
+	const container = document.getElementById("superchat-container");
+
+	// データチェック - 必須項目がない場合はエラーログを出力
+	if (!data || !data.display_name) {
+		console.error("Invalid chat data received:", data);
+		// 元のデータは変更せず、表示用のデータを作成
+		const fallbackData = {
+			display_name: "Unknown User",
+			message: data?.message || "No message content",
+			timestamp: Date.now(),
+		};
+
+		// 安全な表示用データを使用
+		renderChatMessage(container, fallbackData);
+		return;
+	}
+
+	// 正常なデータの場合は表示処理を行う
+	renderChatMessage(container, data);
 }
 
 /**
  * チャットメッセージのレンダリング処理
- * 
+ *
  * @param {HTMLElement} container - メッセージを追加する親要素
  * @param {Object} chatData - レンダリングするチャットデータ
  */
 function renderChatMessage(container, chatData) {
-    // 新しいチャットメッセージ要素を作成 - YouTube風の構造
-    // 実際のYouTubeのHTML構造を参考に、yt-live-chat-text-message-renderer 要素を直接作成
-    const chatElement = document.createElement('yt-live-chat-text-message-renderer');
-    chatElement.className = 'style-scope yt-live-chat-item-list-renderer'; // Add necessary classes
-    chatElement.setAttribute('use-opacity-for-context-menu-visibility', '');
-    chatElement.setAttribute('modern', '');
-    // chatElement.id = `message-${chatData.timestamp}`; // Optional: Add a unique ID
+	// 新しいチャットメッセージ要素を作成 - YouTube風の構造
+	// 実際のYouTubeのHTML構造を参考に、yt-live-chat-text-message-renderer 要素を直接作成
+	const chatElement = document.createElement(
+		"yt-live-chat-text-message-renderer",
+	);
+	chatElement.className = "style-scope yt-live-chat-item-list-renderer"; // Add necessary classes
+	chatElement.setAttribute("use-opacity-for-context-menu-visibility", "");
+	chatElement.setAttribute("modern", "");
+	// chatElement.id = `message-${chatData.timestamp}`; // Optional: Add a unique ID
 
-    // メンバー機能は不要なので、すべて通常リスナー扱いにする
-    // author-type属性は設定しない (実際のHTMLにはauthor-type属性が存在)
-    // if (chatData.author_type) {
-    //     chatElement.setAttribute('author-type', chatData.author_type);
-    // }
-    
-    // チャットメッセージの内容を設定 - 実際のYouTubeのHTML構造を模倣
-    chatElement.innerHTML = `
+	// メンバー機能は不要なので、すべて通常リスナー扱いにする
+	// author-type属性は設定しない (実際のHTMLにはauthor-type属性が存在)
+	// if (chatData.author_type) {
+	//     chatElement.setAttribute('author-type', chatData.author_type);
+	// }
+
+	// チャットメッセージの内容を設定 - 実際のYouTubeのHTML構造を模倣
+	chatElement.innerHTML = `
         <yt-img-shadow id="author-photo" class="no-transition style-scope yt-live-chat-text-message-renderer" height="24" width="24" style="background-color: transparent;" loaded="">
             <!-- ユーザーアイコンはデータに含まれていないため、srcは空またはプレースホルダー -->
             <img id="img" draggable="false" class="style-scope yt-img-shadow" alt="" height="24" width="24" src="">
@@ -218,57 +222,59 @@ function renderChatMessage(container, chatData) {
                 <span id="author-name" dir="auto" class=" style-scope yt-live-chat-author-chip style-scope yt-live-chat-author-chip">${escapeHtml(chatData.display_name)}<span id="chip-badges" class="style-scope yt-live-chat-author-chip"></span></span>
                 <span id="chat-badges" class="style-scope yt-live-chat-author-chip"></span>
             </yt-live-chat-author-chip>
-            <span id="message" dir="auto" class="style-scope yt-live-chat-text-message-renderer">${escapeHtml(chatData.message || '')}</span>
+            <span id="message" dir="auto" class="style-scope yt-live-chat-text-message-renderer">${escapeHtml(chatData.message || "")}</span>
         </div>
         <!-- メニューやアクションボタンはOBS表示では不要なため省略 -->
         <!-- <div id="menu" class="style-scope yt-live-chat-text-message-renderer">...</div> -->
         <!-- <div id="inline-action-button-container" class="style-scope yt-live-chat-text-message-renderer">...</div> -->
     `;
-    
-    // ユーザー名とメッセージの検証を行い、コンソールに表示（デバッグ用）
-    console.log(`Chat message added - User: ${chatData.display_name}, Message: ${chatData.message || '[empty]'}`);
-    
-    // 要素を追加
-    container.appendChild(chatElement);
-    
-    // 最大表示数を超えた場合、古いメッセージを削除
-    cleanupOldMessages();
-    
-    // メッセージ要素を表示領域内に自動スクロール
-    chatElement.scrollIntoView({ behavior: 'smooth', block: 'end' });
+
+	// ユーザー名とメッセージの検証を行い、コンソールに表示（デバッグ用）
+	console.log(
+		`Chat message added - User: ${chatData.display_name}, Message: ${chatData.message || "[empty]"}`,
+	);
+
+	// 要素を追加
+	container.appendChild(chatElement);
+
+	// 最大表示数を超えた場合、古いメッセージを削除
+	cleanupOldMessages();
+
+	// メッセージ要素を表示領域内に自動スクロール
+	chatElement.scrollIntoView({ behavior: "smooth", block: "end" });
 }
 
 /**
  * スーパーチャットメッセージを表示する
  * YouTube風のDOM構造を模倣して表示します
- * 
+ *
  * @param {Object} data - スーパーチャットデータ
  */
 function displaySuperchatMessage(data) {
-    const container = document.getElementById('superchat-container');
-    
-    // データチェック - 必須項目がない場合はエラーログを出力
-    if (!data || !data.display_name) {
-        console.error('Invalid superchat data received:', data);
-        return;
-    }
-    
-    // 新しいスーパーチャット要素を作成 - YouTube風の構造
-    const superchatElement = document.createElement('div');
-    superchatElement.className = 'yt-live-chat-paid-message-renderer';
-    
-    // メッセージの有無に応じてヘッダーのみ表示かを決定
-    if (!data.message || data.message.trim() === '') {
-        superchatElement.setAttribute('show-only-header', '');
-    }
-    
-    // スーパーチャット金額を整形
-    const amount = data.superchat?.amount || 0;
-    const coin = data.superchat?.coin || 'SUI';
-    const formattedAmount = `¥${amount.toLocaleString()}`;
-    
-    // スーパーチャットの内容を設定 - YouTube風の構造
-    superchatElement.innerHTML = `
+	const container = document.getElementById("superchat-container");
+
+	// データチェック - 必須項目がない場合はエラーログを出力
+	if (!data || !data.display_name) {
+		console.error("Invalid superchat data received:", data);
+		return;
+	}
+
+	// 新しいスーパーチャット要素を作成 - YouTube風の構造
+	const superchatElement = document.createElement("div");
+	superchatElement.className = "yt-live-chat-paid-message-renderer";
+
+	// メッセージの有無に応じてヘッダーのみ表示かを決定
+	if (!data.message || data.message.trim() === "") {
+		superchatElement.setAttribute("show-only-header", "");
+	}
+
+	// スーパーチャット金額を整形
+	const amount = data.superchat?.amount || 0;
+	const coin = data.superchat?.coin || "SUI";
+	const formattedAmount = `¥${amount.toLocaleString()}`;
+
+	// スーパーチャットの内容を設定 - YouTube風の構造
+	superchatElement.innerHTML = `
         <div id="card" class="yt-live-chat-paid-message-renderer">
             <div id="header" class="yt-live-chat-paid-message-renderer">
                 <div id="header-content">
@@ -287,77 +293,82 @@ function displaySuperchatMessage(data) {
                     </div>
                 </div>
             </div>
-            ${data.message && data.message.trim() !== '' ? 
-                `<div id="content" class="yt-live-chat-paid-message-renderer">
+            ${
+							data.message && data.message.trim() !== ""
+								? `<div id="content" class="yt-live-chat-paid-message-renderer">
                     <div id="message" dir="auto" class="yt-live-chat-paid-message-renderer">
                         ${escapeHtml(data.message)}
                     </div>
-                </div>` : ''}
+                </div>`
+								: ""
+						}
         </div>
     `;
-    
-    // 要素を追加
-    container.appendChild(superchatElement);
-    
-    // 最大表示数を超えた場合、古いメッセージを削除
-    cleanupOldMessages();
-    
-    // メッセージ要素を表示領域内に自動スクロール
-    superchatElement.scrollIntoView({ behavior: 'smooth', block: 'end' });
+
+	// 要素を追加
+	container.appendChild(superchatElement);
+
+	// 最大表示数を超えた場合、古いメッセージを削除
+	cleanupOldMessages();
+
+	// メッセージ要素を表示領域内に自動スクロール
+	superchatElement.scrollIntoView({ behavior: "smooth", block: "end" });
 }
 
 /**
  * 金額に基づいたCSSクラス名を取得する
- * 
+ *
  * @param {number} amount - スーパーチャット金額
  * @returns {string} - CSSクラス名
  */
 function getAmountClass(amount) {
-    if (amount >= 10) return '10';
-    if (amount >= 5) return '5';
-    if (amount >= 3) return '3';
-    return '1';
+	if (amount >= 10) return "10";
+	if (amount >= 5) return "5";
+	if (amount >= 3) return "3";
+	return "1";
 }
 
 /**
  * 古いメッセージをクリーンアップする
  */
 function cleanupOldMessages() {
-    const container = document.getElementById('superchat-container');
-    const messages = container.querySelectorAll('.chat-message, .superchat-message');
-    
-    // 表示数が最大値を超えた場合、古いメッセージを削除
-    while (messages.length > maxMessages) {
-        container.removeChild(messages[0]);
-    }
+	const container = document.getElementById("superchat-container");
+	const messages = container.querySelectorAll(
+		".chat-message, .superchat-message",
+	);
+
+	// 表示数が最大値を超えた場合、古いメッセージを削除
+	while (messages.length > maxMessages) {
+		container.removeChild(messages[0]);
+	}
 }
 
 /**
  * タイムスタンプをフォーマットする
- * 
+ *
  * @param {number} timestamp - UNIXタイムスタンプ（ミリ秒）
  * @returns {string} - フォーマットされた時刻文字列
  */
 function formatTimestamp(timestamp) {
-    if (!timestamp) return '';
-    
-    const date = new Date(timestamp);
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+	if (!timestamp) return "";
+
+	const date = new Date(timestamp);
+	return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
 /**
  * HTMLエスケープ関数
- * 
+ *
  * @param {string} unsafe - エスケープする文字列
  * @returns {string} - エスケープされた文字列
  */
 function escapeHtml(unsafe) {
-    return unsafe
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;");
+	return unsafe
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;");
 }
 
 /**
@@ -365,16 +376,16 @@ function escapeHtml(unsafe) {
  * メッセージ受信時の視覚的フィードバック
  */
 function blinkConnectionIndicator() {
-    const dotElement = document.getElementById('status-dot');
-    if (!dotElement) return;
-    
-    // 一時的に明るくする
-    dotElement.style.opacity = '1';
-    dotElement.style.transform = 'scale(1.2)';
-    
-    // 少し経ったら元に戻す
-    setTimeout(() => {
-        dotElement.style.opacity = '';
-        dotElement.style.transform = '';
-    }, 300);
+	const dotElement = document.getElementById("status-dot");
+	if (!dotElement) return;
+
+	// 一時的に明るくする
+	dotElement.style.opacity = "1";
+	dotElement.style.transform = "scale(1.2)";
+
+	// 少し経ったら元に戻す
+	setTimeout(() => {
+		dotElement.style.opacity = "";
+		dotElement.style.transform = "";
+	}, 300);
 }

--- a/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
@@ -134,6 +134,7 @@ function setupWebSocketEventHandlers() {
 function updateConnectionStatus(status, statusClass) {
     const statusElement = document.getElementById('connection-status');
     const dotElement = document.getElementById('status-dot');
+    const indicatorElement = document.querySelector('.connection-indicator');
     
     if (statusElement) {
         statusElement.textContent = status;
@@ -144,6 +145,14 @@ function updateConnectionStatus(status, statusClass) {
         dotElement.classList.remove('connected', 'connecting', 'error');
         // 新しいクラスを追加
         dotElement.classList.add(statusClass);
+    }
+    
+    // 接続インジケーター全体にもクラスを適用
+    if (indicatorElement) {
+        // すべてのステータスクラスをリセット
+        indicatorElement.classList.remove('connected', 'connecting', 'error');
+        // 現在のステータスクラスを追加
+        indicatorElement.classList.add(statusClass);
     }
 }
 

--- a/suiperchat_streamer_app/src-tauri/src/static/obs/styles.css
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/styles.css
@@ -1,158 +1,484 @@
 /**
- * SUIperCHAT OBS表示用スタイルシート v1.0.3
+ * SUIperCHAT OBS表示用スタイルシート v1.0.8
  * 
- * OBSブラウザソースで使用するスーパーチャット表示のスタイルを定義します。
- * 配信画面に表示されるスーパーチャットやチャットメッセージの見た目を制御します。
+ * OBSブラウザソースで使用するYouTubeスタイルのチャット表示のスタイルを定義します。
+ * 配信画面に表示されるスーパーチャットやチャットメッセージのYouTubeライクな見た目を実現します。
+ * このCSSはYouTubeスタイルをベースにカスタマイズ可能です。
+ * すべてのユーザーは通常リスナーとして表示されます。
  */
+ 
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Sans+SC:wght@400;500;700&family=Noto+Sans+TC:wght@400;500;700&family=Noto+Sans+KR:wght@400;500;700&family=Noto+Sans:wght@400;500;700&display=swap");
 
+/* ---------------------------------------------------- 
+  カスタマイズ可能な変数
+---------------------------------------------------- */
 :root {
-    --superchat-bg-1: rgba(255, 180, 0, 0.9);  /* 1SUI */
-    --superchat-bg-3: rgba(255, 140, 0, 0.9);  /* 3SUI */
-    --superchat-bg-5: rgba(255, 100, 0, 0.9);  /* 5SUI */
-    --superchat-bg-10: rgba(255, 50, 0, 0.9);  /* 10SUI */
-    --chat-bg: rgba(44, 44, 44, 0.8);          /* 通常チャット */
-    --text-color: #ffffff;
-    --border-radius: 8px;
+  /* リスナー(一般ユーザー)のスタイル */
+  --listener-name: #ffffff;
+  --listener-name-bg: #8ccce3;
+  --listener-comment: #333333;
+  --listener-comment-bg: #ffffff;
+  --listener-comment-border: #8ccce3;
+  
+  /* スーパーチャットのスタイル */
+  --superchat-name: #ffffff;
+  --superchat-name-bg: #62c1de;
+  --superchat-comment: #ffffff;
+  --superchat-comment-bg: #62c1de;
+  --superchat-amount: #ffffff;
+  --superchat-header-height: 48px;
+  
+  /* アニメーションとタイミング */
+  --animation-duration: 0.3s;
+  --animation-delay: 0.1s;
+  
+  /* サイズと間隔 */
+  --border-radius: 24px;
+  --message-padding: 12px 20px;
+  --container-gap: 16px;
 }
 
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+/* ---------------------------------------------------- 
+  ベースフォントとスタイル
+---------------------------------------------------- */
+ytd-sponsorships-live-chat-header-renderer *,
+yt-live-chat-paid-sticker-renderer *,
+yt-live-chat-paid-message-renderer *,
+yt-live-chat-text-message-renderer * {
+  font-family: "Noto Sans JP";
+  font-size: 16px !important;
+  font-style: normal !important;
+  font-weight: 700 !important;
+  line-height: 1.5 !important;
+  letter-spacing: 0.5px !important;
 }
 
+ytd-sponsorships-live-chat-header-renderer #message,
+yt-live-chat-paid-sticker-renderer #message,
+yt-live-chat-paid-message-renderer #message,
+yt-live-chat-text-message-renderer #message {
+  font-weight: 500 !important;
+} 
+
+/* ---------------------------------------------------- 
+  アニメーション
+---------------------------------------------------- */
+ytd-sponsorships-live-chat-header-renderer,
+yt-live-chat-paid-sticker-renderer,
+yt-live-chat-paid-message-renderer,
+yt-live-chat-text-message-renderer {
+  animation: popInLeft var(--animation-duration) ease-out forwards;
+}
+
+@keyframes popInLeft {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+@keyframes popInRight {
+  0% {
+    opacity: 0;
+    transform: translate(50%, -50%) scale(0);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+/* ---------------------------------------------------- 
+  コンテナとレイアウト
+---------------------------------------------------- */
+ytd-sponsorships-live-chat-gift-purchase-announcement-renderer,
+yt-live-chat-paid-sticker-renderer,
+yt-live-chat-paid-message-renderer,
+yt-live-chat-text-message-renderer {
+  padding-left: 16px !important;
+  padding-right: 16px !important;
+  margin-bottom: var(--container-gap) !important;
+}
+
+yt-live-chat-text-message-renderer {
+  flex-direction: row !important;
+  grid-gap: 8px;
+}
+
+#content.yt-live-chat-text-message-renderer {
+  position: relative;
+  overflow: visible !important;
+  display: block;
+}
+
+/* ---------------------------------------------------- 
+  ユーザー名表示
+---------------------------------------------------- */
+yt-live-chat-author-chip.yt-live-chat-text-message-renderer {
+  justify-content: start !important;
+  width: 100%;
+  margin: auto;
+}
+
+/* リスナー名 */
+yt-live-chat-text-message-renderer[author-type="owner"] #author-name,
+yt-live-chat-text-message-renderer[author-type="moderator"] #author-name,
+yt-live-chat-text-message-renderer #author-name {
+  display: block;
+  width: fit-content;
+  padding: 4px 12px !important;
+  border-radius: 18px !important;
+  background-color: var(--listener-name-bg) !important;
+  color: var(--listener-name) !important;
+  font-size: 16px !important;
+  margin-bottom: 8px;
+}
+
+/* アイコン非表示 */
+yt-img-shadow#author-photo.yt-live-chat-text-message-renderer {
+  margin-right: 0px;
+  display: none;
+}
+
+#chat-badges.yt-live-chat-author-chip {
+  display: flex;
+  align-items: center;
+}
+
+/* ---------------------------------------------------- 
+  メッセージ表示
+---------------------------------------------------- */
+/* リスナーメッセージ */
+#message.yt-live-chat-text-message-renderer {
+  background-color: var(--listener-comment-bg) !important;
+  color: var(--listener-comment) !important;
+  border-radius: var(--border-radius);
+  border: 3px solid var(--listener-comment-border);
+  display: block !important;
+  padding: var(--message-padding);
+  width: fit-content !important;
+  position: relative;
+  overflow: visible;
+  margin-right: auto;
+  margin-bottom: 8px;
+}
+
+/* 吹き出しの装飾（左上の角部分） */
+#message.yt-live-chat-text-message-renderer::before {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: -3px; right: auto;
+  width: 21px;
+  height: 21px;
+  transform: rotate(-20deg) skew(20deg, 20deg);
+  background-color: var(--listener-comment-border);
+  border-top-left-radius: 7px;
+  border-bottom-right-radius: 6px;
+  z-index: -1;
+}
+
+#message.yt-live-chat-text-message-renderer::after {
+  content: "";
+  position: absolute;
+  top: 7px;
+  left: 1px; right: auto;
+  width: 18px;
+  height: 18px;
+  transform: rotate(-20deg) skew(20deg, 20deg);
+  background-color: var(--listener-comment-bg);
+  border-top-left-radius: 4px;
+  border-bottom-right-radius: 20px;
+  z-index: 0;
+}
+
+/* ---------------------------------------------------- 
+  スーパーチャット
+---------------------------------------------------- */
+/* カード全体 */
+yt-live-chat-paid-message-renderer #card.yt-live-chat-paid-message-renderer {
+  background-color: var(--superchat-comment-bg);
+  border-radius: 13px;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+}
+
+/* ヘッダー部分 */
+yt-live-chat-paid-message-renderer #header.yt-live-chat-paid-message-renderer {
+  background-color: var(--superchat-name-bg);
+  color: var(--superchat-name);
+  padding: 12px 20px;
+  border-radius: 10px 10px 0 0;
+  position: relative;
+  min-height: var(--superchat-header-height);
+  display: flex;
+  align-items: center;
+}
+
+/* 名前 */
+yt-live-chat-author-chip[disable-highlighting] #author-name.yt-live-chat-author-chip {
+  color: var(--superchat-name);
+  font-size: 18px !important;
+}
+
+/* 金額表示 */
+#purchase-amount-column.yt-live-chat-paid-message-renderer {
+  text-wrap: nowrap;
+  font-size: 22px !important;
+  font-weight: bold !important;
+  color: var(--superchat-amount);
+  position: absolute;
+  right: 20px;
+}
+
+yt-live-chat-paid-message-renderer #purchase-amount {
+  font-size: 22px !important;
+  font-weight: bold !important;
+}
+
+/* ヘッダーのみ表示時 */
+yt-live-chat-paid-message-renderer[show-only-header] #header.yt-live-chat-paid-message-renderer {
+  border-radius: 10px;
+}
+
+yt-live-chat-paid-message-renderer[show-only-header] #content.yt-live-chat-paid-message-renderer {
+  padding: 0;
+}
+
+/* ユーザー情報行 */
+yt-live-chat-paid-message-renderer #single-line.yt-live-chat-paid-message-renderer {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+yt-live-chat-paid-message-renderer #single-line.yt-live-chat-paid-message-renderer span#chat-badges {
+  display: flex;
+  align-items: center;
+}
+
+/* メッセージ部分 */
+yt-live-chat-paid-message-renderer #content.yt-live-chat-paid-message-renderer {
+  background-color: var(--superchat-comment-bg);
+  color: var(--superchat-comment);
+  border-radius: 0 0 10px 10px;
+  padding: 12px 20px;
+  font-size: 16px !important;
+}
+
+/* ボタン等の非表示 */
+#creator-heart-button.yt-live-chat-paid-message-renderer,
+#gradient-container.yt-live-chat-paid-message-renderer,
+#action-buttons.yt-live-chat-paid-message-renderer,
+#before-content-buttons.yt-live-chat-text-message-renderer {
+  display: none !important;
+}
+
+yt-live-chat-paid-message-renderer[has-heart-button] #menu.yt-live-chat-paid-message-renderer {
+  display: none !important;
+}
+
+/* ---------------------------------------------------- 
+  スーパーステッカー
+---------------------------------------------------- */
+/* ステッカー画像 */
+#sticker img {
+  width: 56px !important;
+  height: 56px !important;
+}
+
+/* カード全体 */
+yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed]) #card.yt-live-chat-paid-sticker-renderer {
+  display: block;
+  padding: 0;
+  border-radius: 10px;
+  box-shadow: none;
+  overflow: visible;
+  position: relative;
+}
+
+/* ヘッダー部分 */
+yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed]) #author-info.yt-live-chat-paid-sticker-renderer {
+  background-color: var(--superchat-name-bg);
+  color: var(--superchat-name);
+  border-radius: 10px 10px 0 0;
+  display: block;
+  padding: 12px 20px !important;
+}
+
+/* アイコン非表示 */
+#author-photo.yt-live-chat-paid-sticker-renderer,
+#author-photo.yt-live-chat-paid-message-renderer {
+  display: none !important;
+}
+
+/* ユーザー情報と金額 */
+#content-primary-column.yt-live-chat-paid-sticker-renderer {
+  display: flex;
+  justify-content: space-between;
+}
+
+yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed]) #purchase-amount-chip.yt-live-chat-paid-sticker-renderer {
+  padding: 0;
+  color: var(--superchat-name);
+}
+
+/* ステッカーコンテナ */
+yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed]) #sticker-container {
+  background-color: var(--superchat-comment-bg) !important;
+  display: block;
+  padding: 12px 20px;
+  border-radius: 0 0 10px 10px;
+}
+
+/* ---------------------------------------------------- 
+  その他の要素
+---------------------------------------------------- */
+/* 絵文字サイズ */
+#content.yt-live-chat-paid-message-renderer img.yt-live-chat-paid-message-renderer {
+  width: 18px !important;
+  height: 18px !important;
+}
+
+/* バッジサイズ */
+.yt-live-chat-author-badge-renderer {
+  width: 16px !important;
+  height: 16px !important;
+}
+
+/* 不要な要素を非表示 */
+yt-live-chat-author-badge-renderer[type=moderator],
+yt-live-chat-author-badge-renderer[type=verified],
+yt-live-chat-text-message-renderer #timestamp,
+yt-live-chat-ticker-renderer,
+div#action-panel.style-scope.yt-live-chat-renderer,
+yt-live-chat-upsell-dialog-renderer,
+div#reaction-control-panel-overlay.yt-live-chat-renderer,
+div#separator.yt-live-chat-renderer,
+div#lower-bumper.yt-live-chat-paid-message-renderer,
+ytd-sponsorships-live-chat-gift-redemption-announcement-renderer,
+yt-live-chat-text-message-renderer[is-deleted],
+yt-live-chat-moderation-message-renderer,
+yt-live-chat-auto-mod-message-renderer,
+yt-live-chat-mode-change-message-renderer,
+yt-live-chat-viewer-engagement-message-renderer,
+yt-live-chat-server-error-message,
+yt-live-chat-banner-manager,
+yt-live-chat-restricted-participation-renderer,
+#panel-pages,
+yt-live-chat-message-input-renderer,
+yt-live-chat-header-renderer {
+  display: none !important;
+}
+
+/* 背景透明化 */
+yt-live-chat-renderer {
+  visibility: hidden !important;
+}
+
+yt-live-chat-renderer * {
+  visibility: initial !important;
+}
+
+yt-live-chat-item-list-renderer #items,
+yt-live-chat-item-list-renderer #item-scroller {
+  overflow: hidden !important;
+}
+
+/* 背景を透明に */
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    background-color: transparent;
-    overflow: hidden;
+  overflow: hidden;
+  background-color: rgba(0, 0, 0, 0);
 }
 
+/* リンクスタイル */
+yt-live-chat-text-message-renderer a {
+  text-decoration: none !important;
+}
+
+/* 背景を透明に */
+yt-live-chat-text-message-renderer,
+yt-live-chat-text-message-renderer[is-highlighted],
+yt-live-chat-text-message-renderer[author-type="owner"],
+yt-live-chat-text-message-renderer[author-type="owner"][is-highlighted],
+yt-live-chat-text-message-renderer[author-type="moderator"],
+yt-live-chat-text-message-renderer[author-type="moderator"][is-highlighted] {
+  background-color: transparent !important;
+}
+
+/* その他スタイル調整 */
+.mention.style-scope {
+  background-color: unset;
+}
+
+/* YouTubeのセレクタをサポートするための設定（メンバー関連は削除） */
+yt-live-chat-text-message-renderer[author-type="member"],
+yt-live-chat-text-message-renderer[author-type="member"][is-highlighted] {
+  background-color: transparent !important;
+}
+
+/* ---------------------------------------------------- 
+  SUIperCHAT OBS固有のスタイル
+---------------------------------------------------- */
 .container {
-    width: 100%;
-    max-width: 800px;
-    height: 100vh;
-    margin: 0 auto;
-    padding: 20px;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column-reverse; /* 新しいメッセージを下に表示 */
-    scrollbar-width: thin;          /* Firefox */
-}
-
-/* Chrome/Edge/Safari用スクロールバースタイル */
-.container::-webkit-scrollbar {
-    width: 6px;
-}
-
-.container::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.container::-webkit-scrollbar-thumb {
-    background-color: rgba(255, 255, 255, 0.2);
-    border-radius: 3px;
+  width: 100%;
+  height: 100vh;
+  overflow-y: auto;
+  padding: 10px;
 }
 
 .superchat-container {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--container-gap);
 }
 
-.superchat-message {
-    border-radius: var(--border-radius);
-    padding: 16px;
-    color: var(--text-color);
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    animation: fadeIn 0.5s ease-in-out;
-    max-width: 100%;
-    margin-bottom: 10px;
+/* 接続インジケータのスタイル */
+.connection-indicator {
+  position: fixed;
+  right: 10px;
+  bottom: 10px;
+  font-size: 12px;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  z-index: 1000;
+  opacity: 0.7;
+  transition: opacity 0.3s;
 }
 
-.superchat-message:hover {
-    transform: scale(1.02);
-    transition: transform 0.2s ease;
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 5px;
+  background-color: gray;
+  transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
-.superchat-message.amount-1 {
-    background-color: var(--superchat-bg-1);
+.status-dot.connected {
+  background-color: #4CAF50;
 }
 
-.superchat-message.amount-3 {
-    background-color: var(--superchat-bg-3);
+.status-dot.connecting {
+  background-color: orange;
+  animation: blink 1s infinite;
 }
 
-.superchat-message.amount-5 {
-    background-color: var(--superchat-bg-5);
+.status-dot.error {
+  background-color: #F44336;
 }
 
-.superchat-message.amount-10 {
-    background-color: var(--superchat-bg-10);
-}
-
-.superchat-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 8px;
-}
-
-.display-name {
-    font-weight: bold;
-    font-size: 1.2em;
-}
-
-.amount {
-    font-weight: bold;
-}
-
-.message-content {
-    font-size: 1.1em;
-    word-break: break-word;
-}
-
-/* アニメーション定義 */
-@keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-}
-
-/* 通常チャットメッセージのスタイル */
-.chat-message {
-    border-radius: var(--border-radius);
-    padding: 12px;
-    color: var(--text-color);
-    background-color: var(--chat-bg);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    animation: fadeIn 0.5s ease-in-out;
-    max-width: 100%;
-    margin-bottom: 10px;
-}
-
-.chat-message:hover {
-    transform: scale(1.01);
-    transition: transform 0.2s ease;
-}
-
-.chat-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 6px;
-}
-
-.chat-message .display-name {
-    font-weight: bold;
-    font-size: 1.1em;
-    color: #ffcc00;
-}
-
-.chat-message .timestamp {
-    font-size: 0.8em;
-    color: rgba(255, 255, 255, 0.7);
-}
-
-.chat-message .message-content {
-    font-size: 1em;
-    word-break: break-word;
+@keyframes blink {
+  0% { opacity: 0.3; }
+  50% { opacity: 1; }
+  100% { opacity: 0.3; }
 } 

--- a/suiperchat_streamer_app/src-tauri/src/static/obs/styles.css
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/styles.css
@@ -1,41 +1,41 @@
 /**
  * SUIperCHAT OBS表示用スタイルシート v1.0.8
- * 
+ *
  * OBSブラウザソースで使用するYouTubeスタイルのチャット表示のスタイルを定義します。
  * 配信画面に表示されるスーパーチャットやチャットメッセージのYouTubeライクな見た目を実現します。
  * このCSSはYouTubeスタイルをベースにカスタマイズ可能です。
  * すべてのユーザーは通常リスナーとして表示されます。
  */
- 
+
 @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Sans+SC:wght@400;500;700&family=Noto+Sans+TC:wght@400;500;700&family=Noto+Sans+KR:wght@400;500;700&family=Noto+Sans:wght@400;500;700&display=swap");
 
 /* ---------------------------------------------------- 
   カスタマイズ可能な変数
 ---------------------------------------------------- */
 :root {
-  /* リスナー(一般ユーザー)のスタイル */
-  --listener-name: #ffffff;
-  --listener-name-bg: #8ccce3;
-  --listener-comment: #333333;
-  --listener-comment-bg: #ffffff;
-  --listener-comment-border: #8ccce3;
-  
-  /* スーパーチャットのスタイル */
-  --superchat-name: #ffffff;
-  --superchat-name-bg: #62c1de;
-  --superchat-comment: #ffffff;
-  --superchat-comment-bg: #62c1de;
-  --superchat-amount: #ffffff;
-  --superchat-header-height: 48px;
-  
-  /* アニメーションとタイミング */
-  --animation-duration: 0.3s;
-  --animation-delay: 0.1s;
-  
-  /* サイズと間隔 */
-  --border-radius: 24px;
-  --message-padding: 12px 20px;
-  --container-gap: 16px;
+	/* リスナー(一般ユーザー)のスタイル */
+	--listener-name: #ffffff;
+	--listener-name-bg: #8ccce3;
+	--listener-comment: #333333;
+	--listener-comment-bg: #ffffff;
+	--listener-comment-border: #8ccce3;
+
+	/* スーパーチャットのスタイル */
+	--superchat-name: #ffffff;
+	--superchat-name-bg: #62c1de;
+	--superchat-comment: #ffffff;
+	--superchat-comment-bg: #62c1de;
+	--superchat-amount: #ffffff;
+	--superchat-header-height: 48px;
+
+	/* アニメーションとタイミング */
+	--animation-duration: 0.3s;
+	--animation-delay: 0.1s;
+
+	/* サイズと間隔 */
+	--border-radius: 24px;
+	--message-padding: 12px 20px;
+	--container-gap: 16px;
 }
 
 /* ---------------------------------------------------- 
@@ -45,20 +45,20 @@ ytd-sponsorships-live-chat-header-renderer *,
 yt-live-chat-paid-sticker-renderer *,
 yt-live-chat-paid-message-renderer *,
 yt-live-chat-text-message-renderer * {
-  font-family: "Noto Sans JP";
-  font-size: 16px !important;
-  font-style: normal !important;
-  font-weight: 700 !important;
-  line-height: 1.5 !important;
-  letter-spacing: 0.5px !important;
+	font-family: "Noto Sans JP", sans-serif;
+	font-size: 16px !important;
+	font-style: normal !important;
+	font-weight: 700 !important;
+	line-height: 1.5 !important;
+	letter-spacing: 0.5px !important;
 }
 
 ytd-sponsorships-live-chat-header-renderer #message,
 yt-live-chat-paid-sticker-renderer #message,
 yt-live-chat-paid-message-renderer #message,
 yt-live-chat-text-message-renderer #message {
-  font-weight: 500 !important;
-} 
+	font-weight: 500 !important;
+}
 
 /* ---------------------------------------------------- 
   アニメーション
@@ -67,29 +67,29 @@ ytd-sponsorships-live-chat-header-renderer,
 yt-live-chat-paid-sticker-renderer,
 yt-live-chat-paid-message-renderer,
 yt-live-chat-text-message-renderer {
-  animation: popInLeft var(--animation-duration) ease-out forwards;
+	animation: popInLeft var(--animation-duration) ease-out forwards;
 }
 
 @keyframes popInLeft {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0);
-  }
-  100% {
-    opacity: 1;
-    transform: translate(0, 0) scale(1);
-  }
+	0% {
+		opacity: 0;
+		transform: translate(-50%, -50%) scale(0);
+	}
+	100% {
+		opacity: 1;
+		transform: translate(0, 0) scale(1);
+	}
 }
 
 @keyframes popInRight {
-  0% {
-    opacity: 0;
-    transform: translate(50%, -50%) scale(0);
-  }
-  100% {
-    opacity: 1;
-    transform: translate(0, 0) scale(1);
-  }
+	0% {
+		opacity: 0;
+		transform: translate(50%, -50%) scale(0);
+	}
+	100% {
+		opacity: 1;
+		transform: translate(0, 0) scale(1);
+	}
 }
 
 /* ---------------------------------------------------- 
@@ -99,54 +99,54 @@ ytd-sponsorships-live-chat-gift-purchase-announcement-renderer,
 yt-live-chat-paid-sticker-renderer,
 yt-live-chat-paid-message-renderer,
 yt-live-chat-text-message-renderer {
-  padding-left: 16px !important;
-  padding-right: 16px !important;
-  margin-bottom: var(--container-gap) !important;
+	padding-left: 16px !important;
+	padding-right: 16px !important;
+	margin-bottom: var(--container-gap) !important;
 }
 
 yt-live-chat-text-message-renderer {
-  flex-direction: row !important;
-  grid-gap: 8px;
+	flex-direction: row !important;
+	grid-gap: 8px;
 }
 
 #content.yt-live-chat-text-message-renderer {
-  position: relative;
-  overflow: visible !important;
-  display: block;
+	position: relative;
+	overflow: visible !important;
+	display: block;
 }
 
 /* ---------------------------------------------------- 
   ユーザー名表示
 ---------------------------------------------------- */
 yt-live-chat-author-chip.yt-live-chat-text-message-renderer {
-  justify-content: start !important;
-  width: 100%;
-  margin: auto;
+	justify-content: start !important;
+	width: 100%;
+	margin: auto;
 }
 
 /* リスナー名 */
 yt-live-chat-text-message-renderer[author-type="owner"] #author-name,
 yt-live-chat-text-message-renderer[author-type="moderator"] #author-name,
 yt-live-chat-text-message-renderer #author-name {
-  display: block;
-  width: fit-content;
-  padding: 4px 12px !important;
-  border-radius: 18px !important;
-  background-color: var(--listener-name-bg) !important;
-  color: var(--listener-name) !important;
-  font-size: 16px !important;
-  margin-bottom: 8px;
+	display: block;
+	width: fit-content;
+	padding: 4px 12px !important;
+	border-radius: 18px !important;
+	background-color: var(--listener-name-bg) !important;
+	color: var(--listener-name) !important;
+	font-size: 16px !important;
+	margin-bottom: 8px;
 }
 
 /* アイコン非表示 */
 yt-img-shadow#author-photo.yt-live-chat-text-message-renderer {
-  margin-right: 0px;
-  display: none;
+	margin-right: 0px;
+	display: none;
 }
 
 #chat-badges.yt-live-chat-author-chip {
-  display: flex;
-  align-items: center;
+	display: flex;
+	align-items: center;
 }
 
 /* ---------------------------------------------------- 
@@ -154,46 +154,48 @@ yt-img-shadow#author-photo.yt-live-chat-text-message-renderer {
 ---------------------------------------------------- */
 /* リスナーメッセージ */
 #message.yt-live-chat-text-message-renderer {
-  background-color: var(--listener-comment-bg) !important;
-  color: var(--listener-comment) !important;
-  border-radius: var(--border-radius);
-  border: 3px solid var(--listener-comment-border);
-  display: block !important;
-  padding: var(--message-padding);
-  width: fit-content !important;
-  position: relative;
-  overflow: visible;
-  margin-right: auto;
-  margin-bottom: 8px;
+	background-color: var(--listener-comment-bg) !important;
+	color: var(--listener-comment) !important;
+	border-radius: var(--border-radius);
+	border: 3px solid var(--listener-comment-border);
+	display: block !important;
+	padding: var(--message-padding);
+	width: fit-content !important;
+	position: relative;
+	overflow: visible;
+	margin-right: auto;
+	margin-bottom: 8px;
 }
 
 /* 吹き出しの装飾（左上の角部分） */
 #message.yt-live-chat-text-message-renderer::before {
-  content: "";
-  position: absolute;
-  top: 4px;
-  left: -3px; right: auto;
-  width: 21px;
-  height: 21px;
-  transform: rotate(-20deg) skew(20deg, 20deg);
-  background-color: var(--listener-comment-border);
-  border-top-left-radius: 7px;
-  border-bottom-right-radius: 6px;
-  z-index: -1;
+	content: "";
+	position: absolute;
+	top: 4px;
+	left: -3px;
+	right: auto;
+	width: 21px;
+	height: 21px;
+	transform: rotate(-20deg) skew(20deg, 20deg);
+	background-color: var(--listener-comment-border);
+	border-top-left-radius: 7px;
+	border-bottom-right-radius: 6px;
+	z-index: -1;
 }
 
 #message.yt-live-chat-text-message-renderer::after {
-  content: "";
-  position: absolute;
-  top: 7px;
-  left: 1px; right: auto;
-  width: 18px;
-  height: 18px;
-  transform: rotate(-20deg) skew(20deg, 20deg);
-  background-color: var(--listener-comment-bg);
-  border-top-left-radius: 4px;
-  border-bottom-right-radius: 20px;
-  z-index: 0;
+	content: "";
+	position: absolute;
+	top: 7px;
+	left: 1px;
+	right: auto;
+	width: 18px;
+	height: 18px;
+	transform: rotate(-20deg) skew(20deg, 20deg);
+	background-color: var(--listener-comment-bg);
+	border-top-left-radius: 4px;
+	border-bottom-right-radius: 20px;
+	z-index: 0;
 }
 
 /* ---------------------------------------------------- 
@@ -201,74 +203,80 @@ yt-img-shadow#author-photo.yt-live-chat-text-message-renderer {
 ---------------------------------------------------- */
 /* カード全体 */
 yt-live-chat-paid-message-renderer #card.yt-live-chat-paid-message-renderer {
-  background-color: var(--superchat-comment-bg);
-  border-radius: 13px;
-  position: relative;
-  width: 100%;
-  overflow: hidden;
+	background-color: var(--superchat-comment-bg);
+	border-radius: 13px;
+	position: relative;
+	width: 100%;
+	overflow: hidden;
 }
 
 /* ヘッダー部分 */
 yt-live-chat-paid-message-renderer #header.yt-live-chat-paid-message-renderer {
-  background-color: var(--superchat-name-bg);
-  color: var(--superchat-name);
-  padding: 12px 20px;
-  border-radius: 10px 10px 0 0;
-  position: relative;
-  min-height: var(--superchat-header-height);
-  display: flex;
-  align-items: center;
+	background-color: var(--superchat-name-bg);
+	color: var(--superchat-name);
+	padding: 12px 20px;
+	border-radius: 10px 10px 0 0;
+	position: relative;
+	min-height: var(--superchat-header-height);
+	display: flex;
+	align-items: center;
 }
 
 /* 名前 */
-yt-live-chat-author-chip[disable-highlighting] #author-name.yt-live-chat-author-chip {
-  color: var(--superchat-name);
-  font-size: 18px !important;
+yt-live-chat-author-chip[disable-highlighting]
+	#author-name.yt-live-chat-author-chip {
+	color: var(--superchat-name);
+	font-size: 18px !important;
 }
 
 /* 金額表示 */
 #purchase-amount-column.yt-live-chat-paid-message-renderer {
-  text-wrap: nowrap;
-  font-size: 22px !important;
-  font-weight: bold !important;
-  color: var(--superchat-amount);
-  position: absolute;
-  right: 20px;
+	text-wrap: nowrap;
+	font-size: 22px !important;
+	font-weight: bold !important;
+	color: var(--superchat-amount);
+	position: absolute;
+	right: 20px;
 }
 
 yt-live-chat-paid-message-renderer #purchase-amount {
-  font-size: 22px !important;
-  font-weight: bold !important;
+	font-size: 22px !important;
+	font-weight: bold !important;
 }
 
 /* ヘッダーのみ表示時 */
-yt-live-chat-paid-message-renderer[show-only-header] #header.yt-live-chat-paid-message-renderer {
-  border-radius: 10px;
+yt-live-chat-paid-message-renderer[show-only-header]
+	#header.yt-live-chat-paid-message-renderer {
+	border-radius: 10px;
 }
 
-yt-live-chat-paid-message-renderer[show-only-header] #content.yt-live-chat-paid-message-renderer {
-  padding: 0;
+yt-live-chat-paid-message-renderer[show-only-header]
+	#content.yt-live-chat-paid-message-renderer {
+	padding: 0;
 }
 
 /* ユーザー情報行 */
-yt-live-chat-paid-message-renderer #single-line.yt-live-chat-paid-message-renderer {
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
+yt-live-chat-paid-message-renderer
+	#single-line.yt-live-chat-paid-message-renderer {
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
 }
 
-yt-live-chat-paid-message-renderer #single-line.yt-live-chat-paid-message-renderer span#chat-badges {
-  display: flex;
-  align-items: center;
+yt-live-chat-paid-message-renderer
+	#single-line.yt-live-chat-paid-message-renderer
+	span#chat-badges {
+	display: flex;
+	align-items: center;
 }
 
 /* メッセージ部分 */
 yt-live-chat-paid-message-renderer #content.yt-live-chat-paid-message-renderer {
-  background-color: var(--superchat-comment-bg);
-  color: var(--superchat-comment);
-  border-radius: 0 0 10px 10px;
-  padding: 12px 20px;
-  font-size: 16px !important;
+	background-color: var(--superchat-comment-bg);
+	color: var(--superchat-comment);
+	border-radius: 0 0 10px 10px;
+	padding: 12px 20px;
+	font-size: 16px !important;
 }
 
 /* ボタン等の非表示 */
@@ -276,11 +284,12 @@ yt-live-chat-paid-message-renderer #content.yt-live-chat-paid-message-renderer {
 #gradient-container.yt-live-chat-paid-message-renderer,
 #action-buttons.yt-live-chat-paid-message-renderer,
 #before-content-buttons.yt-live-chat-text-message-renderer {
-  display: none !important;
+	display: none !important;
 }
 
-yt-live-chat-paid-message-renderer[has-heart-button] #menu.yt-live-chat-paid-message-renderer {
-  display: none !important;
+yt-live-chat-paid-message-renderer[has-heart-button]
+	#menu.yt-live-chat-paid-message-renderer {
+	display: none !important;
 }
 
 /* ---------------------------------------------------- 
@@ -288,72 +297,77 @@ yt-live-chat-paid-message-renderer[has-heart-button] #menu.yt-live-chat-paid-mes
 ---------------------------------------------------- */
 /* ステッカー画像 */
 #sticker img {
-  width: 56px !important;
-  height: 56px !important;
+	width: 56px !important;
+	height: 56px !important;
 }
 
 /* カード全体 */
-yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed]) #card.yt-live-chat-paid-sticker-renderer {
-  display: block;
-  padding: 0;
-  border-radius: 10px;
-  box-shadow: none;
-  overflow: visible;
-  position: relative;
+yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed])
+	#card.yt-live-chat-paid-sticker-renderer {
+	display: block;
+	padding: 0;
+	border-radius: 10px;
+	box-shadow: none;
+	overflow: visible;
+	position: relative;
 }
 
 /* ヘッダー部分 */
-yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed]) #author-info.yt-live-chat-paid-sticker-renderer {
-  background-color: var(--superchat-name-bg);
-  color: var(--superchat-name);
-  border-radius: 10px 10px 0 0;
-  display: block;
-  padding: 12px 20px !important;
+yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed])
+	#author-info.yt-live-chat-paid-sticker-renderer {
+	background-color: var(--superchat-name-bg);
+	color: var(--superchat-name);
+	border-radius: 10px 10px 0 0;
+	display: block;
+	padding: 12px 20px !important;
 }
 
 /* アイコン非表示 */
 #author-photo.yt-live-chat-paid-sticker-renderer,
 #author-photo.yt-live-chat-paid-message-renderer {
-  display: none !important;
+	display: none !important;
 }
 
 /* ユーザー情報と金額 */
 #content-primary-column.yt-live-chat-paid-sticker-renderer {
-  display: flex;
-  justify-content: space-between;
+	display: flex;
+	justify-content: space-between;
 }
 
-yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed]) #purchase-amount-chip.yt-live-chat-paid-sticker-renderer {
-  padding: 0;
-  color: var(--superchat-name);
+yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed])
+	#purchase-amount-chip.yt-live-chat-paid-sticker-renderer {
+	padding: 0;
+	color: var(--superchat-name);
 }
 
 /* ステッカーコンテナ */
-yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed]) #sticker-container {
-  background-color: var(--superchat-comment-bg) !important;
-  display: block;
-  padding: 12px 20px;
-  border-radius: 0 0 10px 10px;
+yt-live-chat-paid-sticker-renderer:not([dashboard-money-feed])
+	#sticker-container {
+	background-color: var(--superchat-comment-bg) !important;
+	display: block;
+	padding: 12px 20px;
+	border-radius: 0 0 10px 10px;
 }
 
 /* ---------------------------------------------------- 
   その他の要素
 ---------------------------------------------------- */
 /* 絵文字サイズ */
-#content.yt-live-chat-paid-message-renderer img.yt-live-chat-paid-message-renderer {
-  width: 18px !important;
-  height: 18px !important;
+#content.yt-live-chat-paid-message-renderer
+	img.yt-live-chat-paid-message-renderer {
+	width: 18px !important;
+	height: 18px !important;
 }
 
 /* バッジサイズ */
 .yt-live-chat-author-badge-renderer {
-  width: 16px !important;
-  height: 16px !important;
+	width: 16px !important;
+	height: 16px !important;
 }
 
 /* 不要な要素を非表示 */
-yt-live-chat-author-badge-renderer[type=moderator],
-yt-live-chat-author-badge-renderer[type=verified],
+yt-live-chat-author-badge-renderer[type="moderator"],
+yt-live-chat-author-badge-renderer[type="verified"],
 yt-live-chat-text-message-renderer #timestamp,
 yt-live-chat-ticker-renderer,
 div#action-panel.style-scope.yt-live-chat-renderer,
@@ -373,32 +387,32 @@ yt-live-chat-restricted-participation-renderer,
 #panel-pages,
 yt-live-chat-message-input-renderer,
 yt-live-chat-header-renderer {
-  display: none !important;
+	display: none !important;
 }
 
 /* 背景透明化 */
 yt-live-chat-renderer {
-  visibility: hidden !important;
+	visibility: hidden !important;
 }
 
 yt-live-chat-renderer * {
-  visibility: initial !important;
+	visibility: initial !important;
 }
 
 yt-live-chat-item-list-renderer #items,
 yt-live-chat-item-list-renderer #item-scroller {
-  overflow: hidden !important;
+	overflow: hidden !important;
 }
 
 /* 背景を透明に */
 body {
-  overflow: hidden;
-  background-color: rgba(0, 0, 0, 0);
+	overflow: hidden;
+	background-color: rgba(0, 0, 0, 0);
 }
 
 /* リンクスタイル */
 yt-live-chat-text-message-renderer a {
-  text-decoration: none !important;
+	text-decoration: none !important;
 }
 
 /* 背景を透明に */
@@ -408,77 +422,83 @@ yt-live-chat-text-message-renderer[author-type="owner"],
 yt-live-chat-text-message-renderer[author-type="owner"][is-highlighted],
 yt-live-chat-text-message-renderer[author-type="moderator"],
 yt-live-chat-text-message-renderer[author-type="moderator"][is-highlighted] {
-  background-color: transparent !important;
+	background-color: transparent !important;
 }
 
 /* その他スタイル調整 */
 .mention.style-scope {
-  background-color: unset;
+	background-color: unset;
 }
 
 /* YouTubeのセレクタをサポートするための設定（メンバー関連は削除） */
 yt-live-chat-text-message-renderer[author-type="member"],
 yt-live-chat-text-message-renderer[author-type="member"][is-highlighted] {
-  background-color: transparent !important;
+	background-color: transparent !important;
 }
 
 /* ---------------------------------------------------- 
   SUIperCHAT OBS固有のスタイル
 ---------------------------------------------------- */
 .container {
-  width: 100%;
-  height: 100vh;
-  overflow-y: auto;
-  padding: 10px;
+	width: 100%;
+	height: 100vh;
+	overflow-y: auto;
+	padding: 10px;
 }
 
 .superchat-container {
-  display: flex;
-  flex-direction: column;
-  gap: var(--container-gap);
+	display: flex;
+	flex-direction: column;
+	gap: var(--container-gap);
 }
 
 /* 接続インジケータのスタイル */
 .connection-indicator {
-  position: fixed;
-  right: 10px;
-  bottom: 10px;
-  font-size: 12px;
-  background-color: rgba(0, 0, 0, 0.5);
-  color: white;
-  padding: 4px 8px;
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  z-index: 1000;
-  opacity: 0.7;
-  transition: opacity 0.3s;
+	position: fixed;
+	right: 10px;
+	bottom: 10px;
+	font-size: 12px;
+	background-color: rgba(0, 0, 0, 0.5);
+	color: white;
+	padding: 4px 8px;
+	border-radius: 4px;
+	display: flex;
+	align-items: center;
+	z-index: 1000;
+	opacity: 0.7;
+	transition: opacity 0.3s;
 }
 
 .status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  margin-right: 5px;
-  background-color: gray;
-  transition: transform 0.2s ease, opacity 0.2s ease;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	margin-right: 5px;
+	background-color: gray;
+	transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .status-dot.connected {
-  background-color: #4CAF50;
+	background-color: #4caf50;
 }
 
 .status-dot.connecting {
-  background-color: orange;
-  animation: blink 1s infinite;
+	background-color: orange;
+	animation: blink 1s infinite;
 }
 
 .status-dot.error {
-  background-color: #F44336;
+	background-color: #f44336;
 }
 
 @keyframes blink {
-  0% { opacity: 0.3; }
-  50% { opacity: 1; }
-  100% { opacity: 0.3; }
-} 
+	0% {
+		opacity: 0.3;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0.3;
+	}
+}


### PR DESCRIPTION
# 概要
今回の変更は、OBS表示のユーザーインターフェースをYouTubeのライブチャット風のスタイルに近づけることを目的としています。これにより、視聴者にとってより馴染みやすく、視覚的に魅力的な表示を実現します。また、WebSocket接続状態を示すインジケーターの視認性を向上させました。

# 変更内容
*   `suiperchat_streamer_app/src-tauri/src/static/obs/index.html`
    *   スタイルシートとスクリプトファイルのバージョンを更新しました。
    *   フォントファミリーを `"Noto Sans JP", sans-serif` に変更しました。
    *   接続インジケーターが接続状態のときに透明になるCSSルールを追加しました。
*   `suiperchat_streamer_app/src-tauri/src/static/obs/script.js`
    *   スクリプトファイルのバージョンを更新しました。
    *   YouTube風のDOM構造を生成するためのコメントを追加しました。
    *   `updateConnectionStatus` 関数を修正し、接続状態クラスをインジケーター全体にも適用するようにしました。
    *   通常チャットメッセージの表示処理 (`displayChatMessage`) を修正し、YouTubeのチャットメッセージ (`yt-live-chat-text-message-renderer`) のDOM構造を模倣するように変更しました。
    *   チャットメッセージのレンダリングを行う `renderChatMessage` 関数を新規追加しました。
    *   スーパーチャットメッセージの表示処理 (`displaySuperchatMessage`) を修正し、YouTubeのスーパーチャット (`yt-live-chat-paid-message-renderer`) のDOM構造を模倣するように変更しました。メッセージが空の場合はヘッダーのみ表示するロジックを追加しました。
    *   金額に基づいたCSSクラスを取得する `getAmountClass` 関数を削除しました。
*   `suiperchat_streamer_app/src-tauri/src/static/obs/styles.css`
    *   スタイルシートのバージョンと説明を更新しました。
    *   Noto Sans JP フォントをインポートしました。
    *   リスナー、スーパーチャット、アニメーション、サイズ、間隔に関するカスタマイズ可能なCSS変数を定義しました。
    *   YouTube固有の要素名 (`yt-live-chat-text-message-renderer` など) をターゲットにしたベースフォント、アニメーション、コンテナ、レイアウト、ユーザー名、メッセージ、スーパーチャット、スーパーステッカーのスタイルを追加・修正しました。
    *   吹き出しのようなメッセージ表示のための擬似要素を追加しました。
    *   不要なYouTube固有の要素を非表示にするルールを追加しました。
    *   背景を透明にするスタイルを追加しました。
    *   SUIperCHAT OBS固有の要素 (`.container`, `.superchat-container`, `.connection-indicator`) のスタイルを調整しました。
    *   接続状態を示すドットと点滅アニメーションのスタイルを追加しました。

# (任意) 関連するIssueやチケット
Closes #25 
