### PR TITLE
[feat] YouTube動画ID設定機能の追加と配信者設定の統合

### DIFF
--- a/suiperchat_streamer_app/src-tauri/src/commands/mod.rs
+++ b/suiperchat_streamer_app/src-tauri/src/commands/mod.rs
@@ -6,9 +6,11 @@ pub mod connection;
 pub mod history;
 pub mod server;
 pub mod wallet;
+pub mod youtube;
 
 // モジュールから関数をエクスポート
 pub use connection::{disconnect_client, get_connections_info, set_connection_limits};
 pub use history::get_message_history;
 pub use server::{start_websocket_server, stop_websocket_server};
 pub use wallet::{get_streamer_info, set_wallet_address};
+pub use youtube::set_youtube_video_id;

--- a/suiperchat_streamer_app/src-tauri/src/commands/mod.rs
+++ b/suiperchat_streamer_app/src-tauri/src/commands/mod.rs
@@ -13,4 +13,4 @@ pub use connection::{disconnect_client, get_connections_info, set_connection_lim
 pub use history::get_message_history;
 pub use server::{start_websocket_server, stop_websocket_server};
 pub use wallet::{get_streamer_info, set_wallet_address};
-pub use youtube::set_youtube_video_id;
+pub use youtube::{get_youtube_video_id, set_youtube_video_id};

--- a/suiperchat_streamer_app/src-tauri/src/commands/wallet.rs
+++ b/suiperchat_streamer_app/src-tauri/src/commands/wallet.rs
@@ -17,6 +17,8 @@ pub struct StreamerInfo {
     obs_url: String,
     /// 配信者のSUIウォレットアドレス
     wallet_address: String,
+    /// YouTube動画ID (設定されている場合)
+    youtube_video_id: Option<String>,
 }
 
 /// ## ウォレットアドレスを設定する Tauri コマンド
@@ -132,6 +134,13 @@ pub fn get_streamer_info(app_state: State<'_, AppState>) -> Result<StreamerInfo,
         .ok_or_else(|| "Wallet address is not set. Please configure it first.".to_string())?
         .clone();
 
+    // --- YouTube動画IDを取得 ---
+    let youtube_id_guard = app_state
+        .youtube_video_id
+        .lock()
+        .map_err(|_| "Failed to lock YouTube video ID mutex".to_string())?;
+    let youtube_video_id = youtube_id_guard.clone();
+
     // --- WebSocket URLをAppStateから構築 ---
     let host_guard = app_state
         .host
@@ -169,5 +178,6 @@ pub fn get_streamer_info(app_state: State<'_, AppState>) -> Result<StreamerInfo,
         ws_url,
         obs_url,
         wallet_address,
+        youtube_video_id,
     })
 }

--- a/suiperchat_streamer_app/src-tauri/src/commands/youtube.rs
+++ b/suiperchat_streamer_app/src-tauri/src/commands/youtube.rs
@@ -1,0 +1,68 @@
+//! YouTube関連のコマンド
+//!
+//! YouTube動画IDの設定を行うコマンドを提供します。
+
+use crate::state::AppState;
+use tauri::{command, Emitter, State};
+
+/// ## YouTube動画IDを設定する Tauri コマンド
+///
+/// フロントエンドから受け取ったYouTube動画IDを `AppState` に保存します。
+/// この設定はアプリ起動ごとにリセットされる一時的な設定です。
+///
+/// ### Arguments
+/// - `app_state`: Tauri の管理するアプリケーション状態 (`State<AppState>`)
+/// - `video_id`: 設定するYouTube動画ID (`String`)
+/// - `app_handle`: Tauri アプリケーションハンドル (`tauri::AppHandle`)
+///
+/// ### Returns
+/// - `Result<(), String>`: 成功した場合は `Ok(())`、エラーの場合はエラーメッセージ
+#[command]
+pub fn set_youtube_video_id(
+    app_state: State<'_, AppState>,
+    video_id: String,
+    app_handle: tauri::AppHandle,
+) -> Result<(), String> {
+    println!("Setting YouTube video ID to: {}", video_id);
+
+    let trimmed_video_id = video_id.trim();
+
+    // 動画IDの形式を簡易検証
+    if trimmed_video_id.is_empty() {
+        return Err("YouTube video ID cannot be empty.".to_string());
+    }
+
+    // 文字数の検証（一般的なYouTube動画IDは11文字だが、多少の余裕を持たせる）
+    if trimmed_video_id.len() < 10 || trimmed_video_id.len() > 12 {
+        return Err(format!(
+            "Invalid YouTube video ID length: Expected around 11 characters, got {}.",
+            trimmed_video_id.len()
+        ));
+    }
+
+    // 使用可能な文字のみかチェック（アルファベット、数字、ハイフン、アンダースコア）
+    if !trimmed_video_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err("Invalid YouTube video ID: Contains invalid characters.".to_string());
+    }
+
+    // アドレスを AppState に保存
+    let mut youtube_id = app_state
+        .youtube_video_id
+        .lock()
+        .map_err(|_| "Failed to lock YouTube video ID mutex".to_string())?;
+    *youtube_id = Some(trimmed_video_id.to_string());
+
+    // イベントを発行
+    app_handle
+        .emit("youtube_video_id_updated", ())
+        .map_err(|e| {
+            eprintln!("Failed to emit youtube_video_id_updated event: {}", e);
+            "Failed to notify frontend about YouTube video ID update".to_string()
+        })?;
+    println!("YouTube video ID saved and event 'youtube_video_id_updated' emitted.");
+
+    Ok(())
+}

--- a/suiperchat_streamer_app/src-tauri/src/commands/youtube.rs
+++ b/suiperchat_streamer_app/src-tauri/src/commands/youtube.rs
@@ -3,6 +3,7 @@
 //! YouTube動画IDの設定を行うコマンドを提供します。
 
 use crate::state::AppState;
+use serde_json::json;
 use tauri::{command, Emitter, State};
 
 /// ## YouTube動画IDを設定する Tauri コマンド
@@ -65,4 +66,34 @@ pub fn set_youtube_video_id(
     println!("YouTube video ID saved and event 'youtube_video_id_updated' emitted.");
 
     Ok(())
+}
+
+/// ## YouTube動画IDを取得する Tauri コマンド
+///
+/// 現在設定されているYouTube動画IDを返します。
+///
+/// ### Arguments
+/// - `app_state`: Tauri の管理するアプリケーション状態 (`State<AppState>`)
+///
+/// ### Returns
+/// - `Result<serde_json::Value, String>`: 成功した場合はYouTube動画IDを含むJSON、エラーの場合はエラーメッセージ
+#[command]
+pub fn get_youtube_video_id(app_state: State<'_, AppState>) -> Result<serde_json::Value, String> {
+    println!("Getting YouTube video ID...");
+
+    // YouTube動画IDを取得
+    let youtube_id_guard = app_state
+        .youtube_video_id
+        .lock()
+        .map_err(|_| "Failed to lock YouTube video ID mutex".to_string())?;
+
+    // JSONオブジェクトを作成
+    // youtube_video_idが存在する場合はそれを、存在しない場合はnullを返す
+    let json_result = if let Some(id) = youtube_id_guard.as_ref() {
+        json!({ "youtube_video_id": id })
+    } else {
+        json!({ "youtube_video_id": null })
+    };
+
+    Ok(json_result)
 }

--- a/suiperchat_streamer_app/src-tauri/src/lib.rs
+++ b/suiperchat_streamer_app/src-tauri/src/lib.rs
@@ -28,6 +28,8 @@ pub use commands::wallet::{get_streamer_info, get_wallet_address, set_wallet_add
 pub use commands::connection::{disconnect_client, get_connections_info, set_connection_limits};
 // 履歴関連コマンドの再エクスポート
 pub use commands::history::get_message_history;
+// YouTube関連コマンドの再エクスポート
+pub use commands::youtube::set_youtube_video_id;
 
 /// ## テーブル作成のためのSQL文
 ///
@@ -246,7 +248,9 @@ pub fn run() {
             commands::connection::disconnect_client,
             commands::connection::set_connection_limits,
             // 履歴関連コマンド
-            commands::history::get_message_history
+            commands::history::get_message_history,
+            // YouTube関連コマンド
+            commands::youtube::set_youtube_video_id
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/suiperchat_streamer_app/src-tauri/src/lib.rs
+++ b/suiperchat_streamer_app/src-tauri/src/lib.rs
@@ -29,7 +29,7 @@ pub use commands::connection::{disconnect_client, get_connections_info, set_conn
 // 履歴関連コマンドの再エクスポート
 pub use commands::history::get_message_history;
 // YouTube関連コマンドの再エクスポート
-pub use commands::youtube::set_youtube_video_id;
+pub use commands::youtube::{get_youtube_video_id, set_youtube_video_id};
 
 /// ## テーブル作成のためのSQL文
 ///
@@ -250,7 +250,8 @@ pub fn run() {
             // 履歴関連コマンド
             commands::history::get_message_history,
             // YouTube関連コマンド
-            commands::youtube::set_youtube_video_id
+            commands::youtube::set_youtube_video_id,
+            commands::youtube::get_youtube_video_id
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/suiperchat_streamer_app/src-tauri/src/state.rs
+++ b/suiperchat_streamer_app/src-tauri/src/state.rs
@@ -55,6 +55,11 @@ pub struct AppState {
     ///
     /// トンネルが起動している場合は `Some(Ok(info))`、失敗した場合は `Some(Err(error))`、未起動の場合は `None`
     pub tunnel_info: Arc<Mutex<Option<Result<TunnelInfo, TunnelError>>>>,
+    /// YouTube動画ID
+    ///
+    /// 設定されている場合は `Some(video_id)`、未設定の場合は `None`
+    /// アプリ起動ごとにリセットされる一時的な値
+    pub youtube_video_id: Arc<Mutex<Option<String>>>,
 }
 
 impl AppState {
@@ -76,6 +81,7 @@ impl AppState {
             global_ip_fetch_failed: Arc::new(Mutex::new(false)),
             cgnat_detected: Arc::new(Mutex::new(false)),
             tunnel_info: Arc::new(Mutex::new(None)),
+            youtube_video_id: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
@@ -262,11 +262,16 @@ function displaySuperchatMessage(data) {
 
 	// デバッグ用のログ出力
 	console.log("Displaying superchat message:", data);
-	console.log("Superchat data structure:", JSON.stringify(data.superchat || {}));
+	console.log(
+		"Superchat data structure:",
+		JSON.stringify(data.superchat || {}),
+	);
 
 	// 新しいスーパーチャット要素を作成 - YouTube風の構造
-	const superchatElement = document.createElement("yt-live-chat-paid-message-renderer");
-	
+	const superchatElement = document.createElement(
+		"yt-live-chat-paid-message-renderer",
+	);
+
 	// メッセージの有無に応じてヘッダーのみ表示かを決定
 	if (!data.message || data.message.trim() === "") {
 		superchatElement.setAttribute("show-only-header", "");
@@ -276,14 +281,14 @@ function displaySuperchatMessage(data) {
 	// WebSocketメッセージの型定義に合わせて適切に処理
 	let amount = 0;
 	let coin = "SUI";
-	
+
 	// SuperchatMessageインターフェースに従って処理
 	if (data.superchat) {
 		// 金額を取得（デフォルト0）
 		amount = data.superchat.amount || 0;
 		// コイン種別を取得（デフォルトSUI）
 		coin = data.superchat.coin || "SUI";
-		
+
 		console.log(`Superchat details: Amount=${amount}, Coin=${coin}`);
 	} else {
 		console.warn("Superchat data missing or invalid format");
@@ -317,14 +322,14 @@ function displaySuperchatMessage(data) {
                 <div id="menu" class="yt-live-chat-paid-message-renderer"></div>
             </div>
             ${
-				data.message && data.message.trim() !== ""
-					? `<div id="content" class="yt-live-chat-paid-message-renderer">
+							data.message && data.message.trim() !== ""
+								? `<div id="content" class="yt-live-chat-paid-message-renderer">
                     <div id="message" dir="auto" class="yt-live-chat-paid-message-renderer">
                         ${escapeHtml(data.message)}
                     </div>
                 </div>`
-					: ""
-			}
+								: ""
+						}
             <div id="lower-bumper" class="yt-live-chat-paid-message-renderer"></div>
             <div id="action-buttons" class="yt-live-chat-paid-message-renderer"></div>
             <div id="creator-heart-button" class="yt-live-chat-paid-message-renderer"></div>

--- a/suiperchat_streamer_app/src/app/page.tsx
+++ b/suiperchat_streamer_app/src/app/page.tsx
@@ -1,7 +1,6 @@
 import ServerControl from "@/components/features/dashboard/ServerControl";
+import StreamerConfig from "@/components/features/dashboard/StreamerConfig";
 import UrlDisplay from "@/components/features/dashboard/UrlDisplay";
-import WalletAddressConfig from "@/components/features/dashboard/WalletAddressConfig";
-import YouTubeLinkConfig from "@/components/features/dashboard/YouTubeLinkConfig";
 import { Toaster as SonnerToaster } from "@/components/ui/sonner"; // shadcn/uiのsonnerコンポーネント
 /**
  * SUIperCHAT ルートページコンポーネント (配信者ダッシュボード)
@@ -28,11 +27,8 @@ export default function RootPage(): React.ReactNode {
 		<div className="container mx-auto p-4 space-y-6">
 			<h1 className="text-3xl font-bold">SUIperCHAT Streamer</h1>
 
-			{/* ウォレットアドレス設定コンポーネント */}
-			<WalletAddressConfig />
-
-			{/* YouTube Live URL設定コンポーネント */}
-			<YouTubeLinkConfig />
+			{/* 配信者設定コンポーネント（ウォレットアドレスとYouTube URL） */}
+			<StreamerConfig />
 
 			{/* サーバー制御コンポーネント */}
 			<ServerControl />

--- a/suiperchat_streamer_app/src/app/page.tsx
+++ b/suiperchat_streamer_app/src/app/page.tsx
@@ -1,6 +1,7 @@
 import ServerControl from "@/components/features/dashboard/ServerControl";
 import UrlDisplay from "@/components/features/dashboard/UrlDisplay";
 import WalletAddressConfig from "@/components/features/dashboard/WalletAddressConfig";
+import YouTubeLinkConfig from "@/components/features/dashboard/YouTubeLinkConfig";
 import { Toaster as SonnerToaster } from "@/components/ui/sonner"; // shadcn/uiのsonnerコンポーネント
 /**
  * SUIperCHAT ルートページコンポーネント (配信者ダッシュボード)
@@ -29,6 +30,9 @@ export default function RootPage(): React.ReactNode {
 
 			{/* ウォレットアドレス設定コンポーネント */}
 			<WalletAddressConfig />
+
+			{/* YouTube Live URL設定コンポーネント */}
+			<YouTubeLinkConfig />
 
 			{/* サーバー制御コンポーネント */}
 			<ServerControl />

--- a/suiperchat_streamer_app/src/components/features/dashboard/StreamerConfig.tsx
+++ b/suiperchat_streamer_app/src/components/features/dashboard/StreamerConfig.tsx
@@ -1,0 +1,267 @@
+/**
+ * 配信者設定コンポーネント
+ *
+ * ウォレットアドレスとYouTube LiveのURLを一つのカードにまとめて設定するためのフォームを提供します。
+ * ウォレットアドレスはローカルストレージに保存され、YouTube URLはセッション中のみ保持されます。
+ */
+
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { invoke } from "@tauri-apps/api/core";
+import { Save } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+// ローカルストレージのキー
+const WALLET_ADDRESS_KEY = "suiperchat_wallet_address";
+
+/**
+ * SUIウォレットアドレスの形式を検証する関数
+ * @param {string} address - 検証するアドレス文字列
+ * @returns {string | null} - エラーメッセージ (無効な場合) または null (有効な場合)
+ */
+function validate_sui_address(address: string): string | null {
+	const trimmed_address = address.trim();
+	if (!trimmed_address) {
+		return "Please enter a wallet address.";
+	}
+	if (!trimmed_address.startsWith("0x")) {
+		return "Invalid SUI wallet address: must start with '0x'.";
+	}
+	if (trimmed_address.length !== 66) {
+		return `Invalid SUI wallet address: must be 66 characters long (currently ${trimmed_address.length} characters).`;
+	}
+	// "0x" 以降が16進数文字のみかチェック (正規表現を使用)
+	const hex_pattern = /^[a-fA-F0-9]+$/;
+	if (!hex_pattern.test(trimmed_address.substring(2))) {
+		return "Invalid SUI wallet address: contains non-hexadecimal characters after '0x'.";
+	}
+	return null; // 有効
+}
+
+/**
+ * YouTube URLを検証し、動画IDを抽出する関数
+ * @param {string} url - 検証するYouTube URL
+ * @returns {{ isValid: boolean, videoId?: string, error?: string }} - 検証結果
+ */
+function validateAndExtractYouTubeVideoId(url: string): {
+	isValid: boolean;
+	videoId?: string;
+	error?: string;
+} {
+	// 空のURLをチェック
+	const trimmedUrl = url.trim();
+	if (!trimmedUrl) {
+		return { isValid: false, error: "Please enter a YouTube URL." };
+	}
+
+	// URLの安全性を確認（HTTPSプロトコル）
+	try {
+		const urlObj = new URL(trimmedUrl);
+		if (urlObj.protocol !== "https:") {
+			return {
+				isValid: false,
+				error: "URL must use HTTPS protocol for security.",
+			};
+		}
+
+		// YouTube URLかどうかを確認
+		const isYouTubeUrl =
+			urlObj.hostname === "www.youtube.com" ||
+			urlObj.hostname === "youtube.com" ||
+			urlObj.hostname === "youtu.be" ||
+			urlObj.hostname === "youtube.app.goo.gl";
+
+		if (!isYouTubeUrl) {
+			return { isValid: false, error: "URL must be a valid YouTube URL." };
+		}
+
+		// 各種YouTube URL形式から動画IDを抽出
+		let videoId: string | null = null;
+
+		// 標準的なYouTube URL (youtube.com/watch?v=VIDEO_ID)
+		if (urlObj.pathname === "/watch" && urlObj.searchParams.has("v")) {
+			videoId = urlObj.searchParams.get("v");
+		}
+		// 短縮URL (youtu.be/VIDEO_ID)
+		else if (urlObj.hostname === "youtu.be") {
+			videoId = urlObj.pathname.substring(1); // 先頭の '/' を除去
+		}
+		// ライブ配信URL (youtube.com/live/VIDEO_ID)
+		else if (urlObj.pathname.startsWith("/live/")) {
+			videoId = urlObj.pathname.split("/")[2];
+		}
+		// 埋め込み形式 (youtube.com/embed/VIDEO_ID)
+		else if (urlObj.pathname.startsWith("/embed/")) {
+			videoId = urlObj.pathname.split("/")[2];
+		}
+		// モバイルアプリ共有 (youtube.app.goo.gl/VIDEO_ID)
+		else if (urlObj.hostname === "youtube.app.goo.gl") {
+			// このケースでは完全なURLに変換が必要な場合もある
+			// ここでは単純にパスの最後の部分を取得
+			const pathParts = urlObj.pathname.split("/").filter(Boolean);
+			if (pathParts.length > 0) {
+				videoId = pathParts[pathParts.length - 1];
+			}
+		}
+
+		if (!videoId) {
+			return {
+				isValid: false,
+				error: "Could not extract video ID from the URL.",
+			};
+		}
+
+		// 動画IDの形式を検証（一般的なYouTube動画IDの形式：英数字、ハイフン、アンダースコア、11文字程度）
+		const videoIdPattern = /^[A-Za-z0-9_-]{10,12}$/;
+		if (!videoIdPattern.test(videoId)) {
+			return { isValid: false, error: "Invalid YouTube video ID format." };
+		}
+
+		// サニタイズ処理（念のため再度チェック）
+		videoId = videoId.replace(/[^A-Za-z0-9_-]/g, "");
+
+		return { isValid: true, videoId };
+	} catch (error) {
+		return { isValid: false, error: "Invalid URL format." };
+	}
+}
+
+/**
+ * 配信者設定コンポーネント
+ * @returns {JSX.Element} コンポーネント
+ */
+export default function StreamerConfig() {
+	const [wallet_address, set_wallet_address] = useState("");
+	const [youtube_url, set_youtube_url] = useState("");
+	const [is_saving, set_is_saving] = useState(false);
+
+	/**
+	 * コンポーネントマウント時にローカルストレージから情報を読み込む
+	 */
+	useEffect(() => {
+		const saved_address = localStorage.getItem(WALLET_ADDRESS_KEY);
+		if (saved_address) {
+			set_wallet_address(saved_address);
+		}
+	}, []);
+
+	/**
+	 * 設定を保存する関数
+	 */
+	const handle_save_config = async () => {
+		// --- ウォレットアドレスのバリデーション ---
+		const wallet_validation_error = validate_sui_address(wallet_address);
+		if (wallet_validation_error) {
+			toast.error("Wallet Address Error", {
+				description: wallet_validation_error,
+			});
+			return;
+		}
+
+		// --- YouTube URLのバリデーションと動画ID抽出 ---
+		const youtube_validation_result =
+			validateAndExtractYouTubeVideoId(youtube_url);
+		if (!youtube_validation_result.isValid) {
+			toast.error("YouTube URL Error", {
+				description: youtube_validation_result.error,
+			});
+			return;
+		}
+
+		set_is_saving(true);
+
+		try {
+			// ウォレットアドレスを保存
+			await invoke("set_wallet_address", { address: wallet_address.trim() });
+			console.log("Wallet address sent to backend.");
+
+			// ローカルストレージにも保存
+			localStorage.setItem(WALLET_ADDRESS_KEY, wallet_address);
+
+			// YouTube動画IDを保存
+			await invoke("set_youtube_video_id", {
+				videoId: youtube_validation_result.videoId,
+			});
+			console.log("YouTube video ID sent to backend.");
+
+			// 成功トースト表示
+			toast.success("Saved", {
+				description: "Streamer configuration has been saved.",
+			});
+		} catch (error) {
+			// エラーハンドリング
+			console.error("設定の保存に失敗しました:", error);
+			const error_message =
+				error instanceof Error
+					? error.message
+					: typeof error === "string"
+						? error
+						: "不明なエラーが発生しました。";
+			toast.error("Save Error", {
+				description: `Failed to save configuration: ${error_message}`,
+			});
+		} finally {
+			set_is_saving(false);
+		}
+	};
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>Streamer Configuration</CardTitle>
+				<CardDescription>
+					Set your SUI wallet address and YouTube Live URL. Both settings are
+					required to start the server.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<div className="space-y-2">
+					<Label htmlFor="wallet-address">SUI Wallet Address</Label>
+					<Input
+						id="wallet-address"
+						placeholder="0x..."
+						value={wallet_address}
+						onChange={(e) => set_wallet_address(e.target.value)}
+					/>
+					<p className="text-xs text-muted-foreground">
+						Superchats from viewers will be sent to this address.
+					</p>
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="youtube-url">YouTube Live URL</Label>
+					<Input
+						id="youtube-url"
+						placeholder="https://www.youtube.com/live/..."
+						value={youtube_url}
+						onChange={(e) => set_youtube_url(e.target.value)}
+					/>
+					<p className="text-xs text-muted-foreground">
+						This video will be embedded in the viewer page. Reset when app is
+						restarted.
+					</p>
+				</div>
+
+				<Button
+					onClick={handle_save_config}
+					disabled={is_saving}
+					className="w-full"
+				>
+					<Save className="mr-2 h-4 w-4" />
+					Save Configuration
+				</Button>
+			</CardContent>
+		</Card>
+	);
+}

--- a/suiperchat_streamer_app/src/components/features/dashboard/UrlDisplay.tsx
+++ b/suiperchat_streamer_app/src/components/features/dashboard/UrlDisplay.tsx
@@ -21,6 +21,7 @@ interface StreamerInfo {
 	ws_url: string;
 	obs_url: string;
 	wallet_address: string;
+	youtube_video_id?: string | null;
 }
 
 /**
@@ -173,6 +174,7 @@ export default function UrlDisplay() {
 			ws_url,
 			obs_url: streamerInfoObsUrl,
 			wallet_address,
+			youtube_video_id,
 		} = streamerInfo;
 		try {
 			const encodedWalletAddress = encodeURIComponent(wallet_address);
@@ -202,6 +204,9 @@ export default function UrlDisplay() {
 			// 視聴者 URL - こちらもwsUrlを状態から直接取得可能
 			const wsUrlToUse = wsUrl || ws_url;
 			viewer_url = `${VIEWER_APP_BASE_URL}?wsUrl=${encodeURIComponent(wsUrlToUse)}&streamerAddress=${encodedWalletAddress}`;
+			if (youtube_video_id) {
+				viewer_url += `&videoId=${encodeURIComponent(youtube_video_id)}`;
+			}
 		} catch (encodeError) {
 			console.error("Failed to encode URL parameters:", encodeError);
 			setError("Failed to encode URL parameters.");

--- a/suiperchat_streamer_app/src/components/features/dashboard/YouTubeLinkConfig.tsx
+++ b/suiperchat_streamer_app/src/components/features/dashboard/YouTubeLinkConfig.tsx
@@ -1,0 +1,196 @@
+/**
+ * YouTube Live URL設定コンポーネント
+ *
+ * 配信者のYouTube LiveのURLを設定するためのフォームを提供します。
+ * 設定されたURLは視聴者サイトで埋め込み表示されます。
+ * アプリ起動ごとにリセットされる一時的な設定です。
+ */
+
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { invoke } from "@tauri-apps/api/core";
+import { Save } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+/**
+ * YouTube URLを検証し、動画IDを抽出する関数
+ * @param {string} url - 検証するYouTube URL
+ * @returns {{ isValid: boolean, videoId?: string, error?: string }} - 検証結果
+ */
+function validateAndExtractYouTubeVideoId(url: string): {
+	isValid: boolean;
+	videoId?: string;
+	error?: string;
+} {
+	// 空のURLをチェック
+	const trimmedUrl = url.trim();
+	if (!trimmedUrl) {
+		return { isValid: false, error: "Please enter a YouTube URL." };
+	}
+
+	// URLの安全性を確認（HTTPSプロトコル）
+	try {
+		const urlObj = new URL(trimmedUrl);
+		if (urlObj.protocol !== "https:") {
+			return {
+				isValid: false,
+				error: "URL must use HTTPS protocol for security.",
+			};
+		}
+
+		// YouTube URLかどうかを確認
+		const isYouTubeUrl =
+			urlObj.hostname === "www.youtube.com" ||
+			urlObj.hostname === "youtube.com" ||
+			urlObj.hostname === "youtu.be" ||
+			urlObj.hostname === "youtube.app.goo.gl";
+
+		if (!isYouTubeUrl) {
+			return { isValid: false, error: "URL must be a valid YouTube URL." };
+		}
+
+		// 各種YouTube URL形式から動画IDを抽出
+		let videoId: string | null = null;
+
+		// 標準的なYouTube URL (youtube.com/watch?v=VIDEO_ID)
+		if (urlObj.pathname === "/watch" && urlObj.searchParams.has("v")) {
+			videoId = urlObj.searchParams.get("v");
+		}
+		// 短縮URL (youtu.be/VIDEO_ID)
+		else if (urlObj.hostname === "youtu.be") {
+			videoId = urlObj.pathname.substring(1); // 先頭の '/' を除去
+		}
+		// ライブ配信URL (youtube.com/live/VIDEO_ID)
+		else if (urlObj.pathname.startsWith("/live/")) {
+			videoId = urlObj.pathname.split("/")[2];
+		}
+		// 埋め込み形式 (youtube.com/embed/VIDEO_ID)
+		else if (urlObj.pathname.startsWith("/embed/")) {
+			videoId = urlObj.pathname.split("/")[2];
+		}
+		// モバイルアプリ共有 (youtube.app.goo.gl/VIDEO_ID)
+		else if (urlObj.hostname === "youtube.app.goo.gl") {
+			// このケースでは完全なURLに変換が必要な場合もある
+			// ここでは単純にパスの最後の部分を取得
+			const pathParts = urlObj.pathname.split("/").filter(Boolean);
+			if (pathParts.length > 0) {
+				videoId = pathParts[pathParts.length - 1];
+			}
+		}
+
+		if (!videoId) {
+			return {
+				isValid: false,
+				error: "Could not extract video ID from the URL.",
+			};
+		}
+
+		// 動画IDの形式を検証（一般的なYouTube動画IDの形式：英数字、ハイフン、アンダースコア、11文字程度）
+		const videoIdPattern = /^[A-Za-z0-9_-]{10,12}$/;
+		if (!videoIdPattern.test(videoId)) {
+			return { isValid: false, error: "Invalid YouTube video ID format." };
+		}
+
+		// サニタイズ処理（念のため再度チェック）
+		videoId = videoId.replace(/[^A-Za-z0-9_-]/g, "");
+
+		return { isValid: true, videoId };
+	} catch (error) {
+		return { isValid: false, error: "Invalid URL format." };
+	}
+}
+
+/**
+ * YouTube Live URL設定コンポーネント
+ * @returns {JSX.Element} コンポーネント
+ */
+export default function YouTubeLinkConfig() {
+	const [youtube_url, set_youtube_url] = useState("");
+	const [is_saving, set_is_saving] = useState(false);
+
+	/**
+	 * YouTube URLを検証・保存する関数
+	 */
+	const handle_set_youtube_link = async () => {
+		// URLの検証と動画ID抽出
+		const validation_result = validateAndExtractYouTubeVideoId(youtube_url);
+
+		if (!validation_result.isValid) {
+			toast.error("Input Error", { description: validation_result.error });
+			return;
+		}
+
+		set_is_saving(true);
+
+		try {
+			// Rustバックエンドに動画IDを保存
+			await invoke("set_youtube_video_id", {
+				videoId: validation_result.videoId,
+			});
+			console.log("YouTube video ID sent to backend.");
+
+			// 成功トースト表示
+			toast.success("Saved", {
+				description: "YouTube Live URL has been validated and set.",
+			});
+		} catch (error) {
+			// エラーハンドリング
+			console.error("YouTube URLの設定に失敗しました:", error);
+			const error_message =
+				error instanceof Error
+					? error.message
+					: typeof error === "string"
+						? error
+						: "不明なエラーが発生しました。";
+			toast.error("Save Error", {
+				description: `Failed to set YouTube URL: ${error_message}`,
+			});
+		} finally {
+			set_is_saving(false);
+		}
+	};
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle>YouTube Live URL Configuration</CardTitle>
+				<CardDescription>
+					Set your YouTube Live URL. This video will be embedded in the viewer
+					page.
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<div className="space-y-2">
+					<Label htmlFor="youtube-url">YouTube Live URL</Label>
+					<div className="flex space-x-2">
+						<Input
+							id="youtube-url"
+							placeholder="https://www.youtube.com/live/..."
+							value={youtube_url}
+							onChange={(e) => set_youtube_url(e.target.value)}
+						/>
+						<Button onClick={handle_set_youtube_link} disabled={is_saving}>
+							<Save className="mr-2 h-4 w-4" />
+							Validate & Set URL
+						</Button>
+					</div>
+				</div>
+				<p className="text-sm text-muted-foreground">
+					Note: This setting is temporary and will be reset when the app is
+					restarted.
+				</p>
+			</CardContent>
+		</Card>
+	);
+}

--- a/viewer/src/app/page.tsx
+++ b/viewer/src/app/page.tsx
@@ -22,23 +22,25 @@ import WebSocketUrlHandler from "@/components/websocket/websocket-url-handler";
 import { getServerConfig } from "@/lib/server-config";
 import { Suspense } from "react";
 
+type HomePageProps = {
+	searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
 /**
  * 視聴者向けホームページコンポーネント
  *
- * @param {Object} props - コンポーネントのプロパティ
- * @param {Object} props.searchParams - URLクエリパラメータ
+ * @param {HomePageProps} props - コンポーネントのプロパティ
  * @returns 視聴者ページのJSXエレメント
  */
-export default async function HomePage({
-	searchParams,
-}: {
-	searchParams: { [key: string]: string | string[] | undefined };
-}) {
+export default async function HomePage({ searchParams }: HomePageProps) {
+	// searchParams を await で解決
+	const resolvedSearchParams = await searchParams;
+
 	// サーバー設定を取得
 	const config = await getServerConfig();
 
 	// URLクエリパラメータから動画IDを取得
-	const videoId = searchParams.videoId as string | undefined;
+	const videoId = resolvedSearchParams.videoId as string | undefined;
 
 	// YouTube埋め込み用のURLを生成
 	let videoUrl =

--- a/viewer/src/app/page.tsx
+++ b/viewer/src/app/page.tsx
@@ -25,11 +25,29 @@ import { Suspense } from "react";
 /**
  * 視聴者向けホームページコンポーネント
  *
+ * @param {Object} props - コンポーネントのプロパティ
+ * @param {Object} props.searchParams - URLクエリパラメータ
  * @returns 視聴者ページのJSXエレメント
  */
-export default async function HomePage() {
+export default async function HomePage({
+	searchParams,
+}: {
+	searchParams: { [key: string]: string | string[] | undefined };
+}) {
 	// サーバー設定を取得
 	const config = await getServerConfig();
+
+	// URLクエリパラメータから動画IDを取得
+	const videoId = searchParams.videoId as string | undefined;
+
+	// YouTube埋め込み用のURLを生成
+	let videoUrl =
+		config?.streamUrl || "https://www.youtube.com/watch?v=jfKfPfyJRdk";
+
+	// 動画IDが指定されている場合はYouTube埋め込みURLを作成
+	if (videoId) {
+		videoUrl = `https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0`;
+	}
 
 	return (
 		<>
@@ -43,10 +61,7 @@ export default async function HomePage() {
 				<ViewerLayout
 					video_player={
 						<VideoPlayer
-							video_url={
-								config?.streamUrl ||
-								"https://www.youtube.com/watch?v=jfKfPfyJRdk"
-							}
+							video_url={videoUrl}
 							fallback_content={
 								<div className="w-full h-full flex items-center justify-center bg-muted">
 									<p className="text-center p-4">


### PR DESCRIPTION
# 概要
このプルリクエストは、配信者がYouTube動画IDを設定し、視聴者ページでその動画を埋め込み表示できるようにする新機能を追加します。また、既存のウォレットアドレス設定とYouTube動画ID設定を一つの「配信者設定」コンポーネントに統合し、サーバー起動前に両方の設定が完了していることを確認するよう改善しました。これにより、配信者の設定体験が向上し、視聴者へのコンテンツ提供がよりスムーズになります。

# 変更内容
*   `suiperchat_streamer_app/src-tauri/src/commands/mod.rs`
    *   `youtube` モジュールが追加され、`get_youtube_video_id` と `set_youtube_video_id` 関数がエクスポートされました。
*   `suiperchat_streamer_app/src-tauri/src/commands/wallet.rs`
    *   `StreamerInfo` 構造体に `youtube_video_id: Option<String>` フィールドが追加されました。
    *   `get_streamer_info` 関数が `youtube_video_id` を取得し、`StreamerInfo` に含めるように変更されました。
*   `suiperchat_streamer_app/src-tauri/src/commands/youtube.rs`
    *   新規追加: YouTube動画IDの設定 (`set_youtube_video_id`) と取得 (`get_youtube_video_id`) を行うTauriコマンドが実装されました。動画IDのバリデーションも含まれます。
*   `suiperchat_streamer_app/src-tauri/src/lib.rs`
    *   `youtube` モジュールからのコマンド (`get_youtube_video_id`, `set_youtube_video_id`) が再エクスポートされ、Tauriアプリケーションに登録されました。
*   `suiperchat_streamer_app/src-tauri/src/state.rs`
    *   `AppState` 構造体に `youtube_video_id: Arc<Mutex<Option<String>>>` フィールドが追加され、YouTube動画IDをアプリケーションの状態として管理できるようになりました。
*   `suiperchat_streamer_app/src-tauri/src/static/obs/script.js`
    *   スーパーチャットメッセージ表示ロジックのコンソールログ出力とHTMLテンプレートのフォーマットが調整されました。機能的な変更はありません。
*   `suiperchat_streamer_app/src/app/page.tsx`
    *   既存の `WalletAddressConfig` コンポーネントが削除され、ウォレットアドレスとYouTube URLの設定を統合した新しい `StreamerConfig` コンポーネントが追加されました。
*   `suiperchat_streamer_app/src/components/features/dashboard/ServerControl.tsx`
    *   サーバー起動前に、ウォレットアドレスとYouTube動画IDの両方が設定されているかを確認するロジックが追加されました。
    *   設定が不足している場合のユーザーへの通知メッセージが改善されました。
*   `suiperchat_streamer_app/src/components/features/dashboard/StreamerConfig.tsx`
    *   新規追加: SUIウォレットアドレスとYouTube Live URLをまとめて設定するためのフォームコンポーネントです。入力値のバリデーション機能も含まれます。
*   `suiperchat_streamer_app/src/components/features/dashboard/UrlDisplay.tsx`
    *   `StreamerInfo` インターフェースに `youtube_video_id` フィールドが追加されました。
    *   視聴者URLを生成する際に、`youtube_video_id` が存在すればURLクエリパラメータとして追加されるようになりました。
*   `suiperchat_streamer_app/src/components/features/dashboard/YouTubeLinkConfig.tsx`
    *   削除: `StreamerConfig.tsx` に機能が統合されたため、このファイルは不要になりました。
*   `viewer/src/app/page.tsx`
    *   URLクエリパラメータから `videoId` を取得する機能が追加されました。
    *   取得した `videoId` を使用してYouTube埋め込み用のURLを生成し、`VideoPlayer` コンポーネントに渡すことで、視聴者ページで指定されたYouTube動画が表示されるようになりました。

# (任意) 関連するIssueやチケット
Closes: #29 
