### PR TITLE
Add build tools guidance in README

### DIFF
--- a/suiperchat_streamer_app/README.md
+++ b/suiperchat_streamer_app/README.md
@@ -19,6 +19,8 @@ SuiperCHAT Streamer App は、SuiperCHAT サービスを利用するストリー
 
 - パソコン (Windows または macOS)
 - インターネット接続
+- Windows では Visual Studio Build Tools（C++ Build Tools）をインストール
+- macOS では Xcode Command Line Tools をインストール
 
 ## セットアップ (使い方)
 


### PR DESCRIPTION
## Summary
- README に Windows と macOS 向けのビルドツールインストール案内を追加

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683fe1d0ef04832ebf564c056fe9ab03