### PR TITLE
[fix] 金額入力時の小数点表示問題を修正

### DIFF
--- a/viewer/src/components/comments/comment-list.tsx
+++ b/viewer/src/components/comments/comment-list.tsx
@@ -222,10 +222,9 @@ export function CommentList({
 					<div className="flex items-center justify-center py-1 border-b">
 						<Loader2 className="h-4 w-4 animate-spin mr-2" />
 						<span className="text-sm text-muted-foreground">
-							{sortedMessages.length === 0 
-								? "コメント履歴を読み込み中..." 
-								: "過去のコメントを読み込み中..."
-							}
+							{sortedMessages.length === 0
+								? "コメント履歴を読み込み中..."
+								: "過去のコメントを読み込み中..."}
 						</span>
 					</div>
 				)}

--- a/viewer/src/components/providers/WebSocketProvider.tsx
+++ b/viewer/src/components/providers/WebSocketProvider.tsx
@@ -9,8 +9,8 @@
 import { useWebSocketConnectionManager } from "@/hooks/useWebSocketConnect"; // 接続管理ロジック
 import { useWebSocketMessageHandler } from "@/hooks/useWebSocketMessage"; // メッセージ処理ロジック
 import {
-	ConnectionStatus,
 	type ChatMessage,
+	ConnectionStatus,
 	type HistoryDataMessage,
 	MessageType,
 	type SuperchatMessage,
@@ -86,42 +86,46 @@ export function WebSocketProvider({
 	});
 
 	// WebSocketメッセージハンドラの拡張 (過去ログ処理用)
-	const handleHistoryMessage = useCallback((data: { messages?: (ChatMessage | SuperchatMessage)[]; has_more?: boolean }) => {
-		console.debug(`履歴データ受信: ${data.messages?.length || 0}件`);
+	const handleHistoryMessage = useCallback(
+		(data: {
+			messages?: (ChatMessage | SuperchatMessage)[];
+			has_more?: boolean;
+		}) => {
+			console.debug(`履歴データ受信: ${data.messages?.length || 0}件`);
 
-		setState((prev) => {
-			// サーバーからのレスポンス形式に対応
-			const messages = data.messages || [];
-			const hasMore = data.has_more || false;
+			setState((prev) => {
+				// サーバーからのレスポンス形式に対応
+				const messages = data.messages || [];
+				const hasMore = data.has_more || false;
 
-			// 既存メッセージのIDを取得
-			const existingMessageIds = new Set(prev.messages.map((msg) => msg.id));
+				// 既存メッセージのIDを取得
+				const existingMessageIds = new Set(prev.messages.map((msg) => msg.id));
 
-			// 重複を除外して新しいメッセージを追加
-			const newMessages = [
-				...messages.filter(
-					(msg) => !existingMessageIds.has(msg.id),
-				),
-				...prev.messages,
-			];
+				// 重複を除外して新しいメッセージを追加
+				const newMessages = [
+					...messages.filter((msg) => !existingMessageIds.has(msg.id)),
+					...prev.messages,
+				];
 
-			// メッセージをタイムスタンプでソート
-			newMessages.sort((a, b) => a.timestamp - b.timestamp);
+				// メッセージをタイムスタンプでソート
+				newMessages.sort((a, b) => a.timestamp - b.timestamp);
 
-			// 最も古いメッセージのタイムスタンプを更新
-			const oldestMessage = newMessages[0];
-			const oldestTimestamp = oldestMessage ? oldestMessage.timestamp : null;
+				// 最も古いメッセージのタイムスタンプを更新
+				const oldestMessage = newMessages[0];
+				const oldestTimestamp = oldestMessage ? oldestMessage.timestamp : null;
 
-			return {
-				...prev,
-				messages: newMessages,
-				isLoadingHistory: false,
-				hasMoreHistory: hasMore,
-				historyError: null,
-				oldestMessageTimestamp: oldestTimestamp,
-			};
-		});
-	}, []);
+				return {
+					...prev,
+					messages: newMessages,
+					isLoadingHistory: false,
+					hasMoreHistory: hasMore,
+					historyError: null,
+					oldestMessageTimestamp: oldestTimestamp,
+				};
+			});
+		},
+		[],
+	);
 
 	// カスタムメッセージハンドラ (メッセージタイプに応じて処理を振り分け)
 	const customHandleMessage = useCallback(

--- a/viewer/src/components/superchat/superchat-form.tsx
+++ b/viewer/src/components/superchat/superchat-form.tsx
@@ -622,36 +622,68 @@ export function SuperchatForm({
 							<FormField
 								control={form.control}
 								name="amount"
-								render={({ field: { onChange, value, ...field } }) => (
-									<FormItem className="flex-grow">
-										<Input
-											type="text"
-											placeholder="金額"
-											inputMode="decimal"
-											pattern="[0-9]*\.?[0-9]*"
-											{...field}
-											value={value === 0 ? "" : value.toString()}
-											onChange={(e) => {
-												const inputValue = e.target.value;
-												// 空文字の場合は0をセット
-												if (inputValue === "") {
-													onChange(0);
-													return;
-												}
-												// 数値として妥当な形式かチェック
-												if (/^\d*\.?\d*$/.test(inputValue)) {
-													const val = Number.parseFloat(inputValue);
-													// NaNでない場合のみ更新
-													if (!Number.isNaN(val)) {
-														onChange(val);
+								render={({ field: { onChange, value, ...field } }) => {
+									// 表示用の値を管理（入力中の状態を保持）
+									const [displayValue, setDisplayValue] = useState(
+										value === 0 ? "" : value.toString(),
+									);
+
+									// valueが外部から変更された場合に表示値を更新
+									useEffect(() => {
+										setDisplayValue(value === 0 ? "" : value.toString());
+									}, [value]);
+
+									return (
+										<FormItem className="flex-grow">
+											<Input
+												type="text"
+												placeholder="金額"
+												inputMode="decimal"
+												pattern="[0-9]*\.?[0-9]*"
+												{...field}
+												value={displayValue}
+												onChange={(e) => {
+													const inputValue = e.target.value;
+
+													// 空文字の場合
+													if (inputValue === "") {
+														setDisplayValue("");
+														onChange(0);
+														return;
 													}
-												}
-											}}
-											className="text-xs h-6"
-										/>
-										<FormMessage />
-									</FormItem>
-								)}
+
+													// 数値として妥当な形式かチェック（末尾のドットも許可）
+													if (/^\d*\.?\d*$/.test(inputValue)) {
+														setDisplayValue(inputValue);
+
+														// 数値に変換可能な場合のみフォームの値を更新
+														// 末尾が.の場合は変換しない（入力中のため）
+														if (!inputValue.endsWith(".")) {
+															const val = Number.parseFloat(inputValue);
+															if (!Number.isNaN(val)) {
+																onChange(val);
+															}
+														}
+													}
+												}}
+												onBlur={() => {
+													// フォーカスが外れたときに表示値を整形
+													if (
+														displayValue !== "" &&
+														!displayValue.endsWith(".")
+													) {
+														const val = Number.parseFloat(displayValue);
+														if (!Number.isNaN(val)) {
+															setDisplayValue(val.toString());
+														}
+													}
+												}}
+												className="text-xs h-6"
+											/>
+											<FormMessage />
+										</FormItem>
+									);
+								}}
 							/>
 						</div>
 					)}

--- a/viewer/src/components/superchat/superchat-form.tsx
+++ b/viewer/src/components/superchat/superchat-form.tsx
@@ -625,18 +625,27 @@ export function SuperchatForm({
 								render={({ field: { onChange, value, ...field } }) => (
 									<FormItem className="flex-grow">
 										<Input
-											type="number"
+											type="text"
 											placeholder="金額"
-											step="any"
-											min="0"
+											inputMode="decimal"
+											pattern="[0-9]*\.?[0-9]*"
 											{...field}
-											value={value === 0 ? "" : value}
+											value={value === 0 ? "" : value.toString()}
 											onChange={(e) => {
-												const val =
-													e.target.value === ""
-														? 0
-														: Number.parseFloat(e.target.value);
-												onChange(val);
+												const inputValue = e.target.value;
+												// 空文字の場合は0をセット
+												if (inputValue === "") {
+													onChange(0);
+													return;
+												}
+												// 数値として妥当な形式かチェック
+												if (/^\d*\.?\d*$/.test(inputValue)) {
+													const val = Number.parseFloat(inputValue);
+													// NaNでない場合のみ更新
+													if (!Number.isNaN(val)) {
+														onChange(val);
+													}
+												}
 											}}
 											className="text-xs h-6"
 										/>


### PR DESCRIPTION
## 概要
Viewerアプリの金額入力フィールドで、小数点を含む数値（0.1など）が正しく表示されない問題を修正しました。

## 変更内容
- `viewer/src/components/superchat/superchat-form.tsx`
    - type="number"からtype="text"に変更し、カスタム数値検証を実装
    - inputMode="decimal"を追加してモバイルで数値キーボードを表示
    - 入力中の状態を保持するdisplayValueステートを追加
    - 小数点入力中（0.など）の状態を正しく維持する処理を実装
    - onBlurイベントで表示値の整形処理を追加
- `viewer/src/components/comments/comment-list.tsx`
    - Biomeによる自動フォーマット
- `viewer/src/components/providers/WebSocketProvider.tsx`
    - Biomeによる自動フォーマット

## 関連するIssueやチケット
Close #39

## スクリーンショットや動作確認
- 0.1と入力して正しく0.1と表示されることを確認
- 1.23などの他の小数点を含む数値も正しく表示されることを確認
- 数値以外の文字が入力できないことを確認
- モバイルで数値キーボードが表示されることを確認