### PR TITLE
[fix] OBSチャット表示の自動スクロール機能を改善

### DIFF
--- a/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/script.js
@@ -356,8 +356,10 @@ function renderChatMessage(container, chatData, isHistory = false) {
 
 	// 履歴メッセージの場合はスクロールを抑制
 	if (!isHistory) {
-		// メッセージ要素を表示領域内に自動スクロール
-		chatElement.scrollIntoView({ behavior: "smooth", block: "end" });
+		// 確実に最下部にスクロール
+		setTimeout(() => {
+			container.scrollTop = container.scrollHeight;
+		}, 50);
 	}
 }
 
@@ -474,8 +476,10 @@ function displaySuperchatMessage(data, isHistory = false) {
 
 	// 履歴メッセージの場合はスクロールを抑制
 	if (!isHistory) {
-		// メッセージ要素を表示領域内に自動スクロール
-		superchatElement.scrollIntoView({ behavior: "smooth", block: "end" });
+		// 確実に最下部にスクロール
+		setTimeout(() => {
+			container.scrollTop = container.scrollHeight;
+		}, 50);
 	}
 }
 

--- a/suiperchat_streamer_app/src-tauri/src/static/obs/styles.css
+++ b/suiperchat_streamer_app/src-tauri/src/static/obs/styles.css
@@ -443,7 +443,9 @@ yt-live-chat-text-message-renderer[author-type="member"][is-highlighted] {
 	width: 100%;
 	height: 100vh;
 	overflow-y: auto;
+	overflow-x: hidden;
 	padding: 10px;
+	scroll-behavior: smooth;
 }
 
 .superchat-container {


### PR DESCRIPTION
## 概要
OBSのチャット表示において、新しいメッセージが投稿された際の自動スクロール機能を改善し、確実に最下部まで表示されるように修正しました。

## 変更内容
- `suiperchat_streamer_app/src-tauri/src/static/obs/script.js`
    - scrollIntoViewの代わりにcontainer.scrollTopを使用した確実なスクロール実装
    - 新規メッセージ（チャット・スーパーチャット）で50ms後に最下部へスクロール
    - 履歴メッセージ読み込み時はスクロールを抑制する仕組みを維持
- `suiperchat_streamer_app/src-tauri/src/static/obs/styles.css`
    - コンテナにoverflow-x: hiddenを追加して横スクロールを防止
    - scroll-behavior: smoothを追加してスムーズなスクロール動作を実現
- `.gitignore`
    - vscode_cli.tar.gzファイルを無視リストに追加（開発環境用ファイル）
- `viewer/package.json`
    - バージョン番号を0.4.2に更新（既にmainブランチで適用済み）