### PR TITLE
[fix] コメント重なり問題の修正とUI改善

### DIFF
--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "viewer",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"private": true,
 	"scripts": {
 		"dev": "next dev --turbopack",

--- a/viewer/src/components/comments/comment-list.tsx
+++ b/viewer/src/components/comments/comment-list.tsx
@@ -76,18 +76,11 @@ export function CommentList({
 		return [...messages].sort((a, b) => a.timestamp - b.timestamp);
 	}, [messages]);
 
-	// 各アイテムの高さを推定する関数（measureElementによる実測値に依存するため簡略化）
-	const estimateItemSize = useCallback(
-		(index: number) => {
-			const message = sortedMessages[index];
-			// メッセージが存在しない場合はデフォルト値を返す
-			if (!message) return 22;
-
-			// メッセージの種類に応じて最低限の高さを設定（実測値で自動調整される）
-			return message.type === MessageType.SUPERCHAT ? 40 : 22;
-		},
-		[sortedMessages],
-	);
+	// 各アイテムの高さを推定する関数（measureElementによる実測で正確な高さに調整される）
+	const estimateItemSize = useCallback(() => {
+		// 最小限の初期値のみ設定、実測で上書きされる
+		return 50;
+	}, []);
 
 	// 仮想スクロールの設定
 	const virtualizer = useVirtualizer({

--- a/viewer/src/components/comments/comment-list.tsx
+++ b/viewer/src/components/comments/comment-list.tsx
@@ -303,7 +303,7 @@ function CommentItem({ comment }: CommentItemProps) {
 		<div
 			className={cn(
 				is_superchat
-					? "py-0.5 px-1.5 text-sm h-full shadow-sm border-b border-border/5"
+					? "py-0.5 px-1.5 text-sm min-h-full shadow-sm border-b border-border/5 overflow-hidden"
 					: "py-0 px-1 text-xs h-full hover:bg-secondary/5 transition-colors border-b border-border/5",
 				is_superchat ? `${getSuperchatBgColor()} text-white` : "",
 			)}
@@ -319,7 +319,7 @@ function CommentItem({ comment }: CommentItemProps) {
 							{(comment as SuperchatMessage).superchat.amount} SUI
 						</span>
 					</div>
-					<div className="font-medium text-white text-xs mt-0.5 leading-tight whitespace-pre-wrap break-words break-all overflow-hidden w-full">
+					<div className="font-medium text-white text-xs mt-0.5 leading-tight whitespace-pre-wrap break-words break-all w-full max-h-20 overflow-y-auto">
 						{comment.message}
 					</div>
 				</>

--- a/viewer/src/components/comments/comment-list.tsx
+++ b/viewer/src/components/comments/comment-list.tsx
@@ -234,7 +234,6 @@ export function CommentList({
 								ref={virtualizer.measureElement}
 								className="absolute left-1 w-full"
 								style={{
-									height: `${virtualItem.size}px`,
 									transform: `translateY(${virtualItem.start}px)`,
 								}}
 							>
@@ -296,8 +295,8 @@ function CommentItem({ comment }: CommentItemProps) {
 		<div
 			className={cn(
 				is_superchat
-					? "py-0.5 px-1.5 text-sm min-h-full shadow-sm border-b border-border/5 overflow-hidden"
-					: "py-0 px-1 text-xs h-full hover:bg-secondary/5 transition-colors border-b border-border/5",
+					? "py-0.5 px-1.5 text-sm shadow-sm border-b border-border/5"
+					: "py-0 px-1 text-xs hover:bg-secondary/5 transition-colors border-b border-border/5",
 				is_superchat ? `${getSuperchatBgColor()} text-white` : "",
 			)}
 		>

--- a/viewer/src/components/comments/comment-list.tsx
+++ b/viewer/src/components/comments/comment-list.tsx
@@ -76,35 +76,15 @@ export function CommentList({
 		return [...messages].sort((a, b) => a.timestamp - b.timestamp);
 	}, [messages]);
 
-	// 各アイテムの高さを推定する関数
+	// 各アイテムの高さを推定する関数（measureElementによる実測値に依存するため簡略化）
 	const estimateItemSize = useCallback(
 		(index: number) => {
 			const message = sortedMessages[index];
 			// メッセージが存在しない場合はデフォルト値を返す
 			if (!message) return 22;
 
-			// メッセージの種類に応じて基本高さを設定
-			const baseHeight = message.type === MessageType.SUPERCHAT ? 40 : 22;
-
-			// メッセージの長さから追加の高さを計算
-			const messageText = message.message || "";
-			const messageLength = messageText.length;
-
-			// スーパーチャットと通常メッセージで異なる計算を適用
-			if (message.type === MessageType.SUPERCHAT) {
-				// スーパーチャットは1行あたり約30文字として計算
-				const estimatedLines = Math.ceil(messageLength / 30);
-				// 基本高さに各行の高さを加算（1行目は基本高さに含まれる）
-				return baseHeight + Math.max(0, estimatedLines - 1) * 16; // 追加の各行に16px
-			}
-
-			// 通常コメントは1行あたり約40文字として計算
-			// 改行コードも考慮
-			const newlineCount = (messageText.match(/\n/g) || []).length;
-			const textLines = Math.ceil(messageLength / 40) + newlineCount;
-
-			// 通常は1行で収まるように設計されているため、追加行がある場合のみ高さを増加
-			return baseHeight + Math.max(0, textLines - 1) * 16;
+			// メッセージの種類に応じて最低限の高さを設定（実測値で自動調整される）
+			return message.type === MessageType.SUPERCHAT ? 40 : 22;
 		},
 		[sortedMessages],
 	);
@@ -115,7 +95,7 @@ export function CommentList({
 		getScrollElement: () => parentElement,
 		estimateSize: estimateItemSize,
 		overscan: 10, // スクロール時により多くのアイテムを事前に描画
-		gap: 0, // アイテム間のギャップを0に設定
+		gap: 2, // アイテム間のギャップを2pxに設定
 	});
 
 	// 親要素の設定
@@ -259,7 +239,7 @@ export function CommentList({
 								key={virtualItem.key}
 								data-index={virtualItem.index}
 								ref={virtualizer.measureElement}
-								className="absolute top-1.5 left-1 w-full"
+								className="absolute left-1 w-full"
 								style={{
 									height: `${virtualItem.size}px`,
 									transform: `translateY(${virtualItem.start}px)`,

--- a/viewer/src/components/comments/comment-list.tsx
+++ b/viewer/src/components/comments/comment-list.tsx
@@ -319,7 +319,7 @@ function CommentItem({ comment }: CommentItemProps) {
 							{(comment as SuperchatMessage).superchat.amount} SUI
 						</span>
 					</div>
-					<div className="font-medium text-white text-xs mt-0.5 leading-tight whitespace-pre-wrap break-words break-all w-full max-h-20 overflow-y-auto">
+					<div className="font-medium text-white text-xs mt-0.5 leading-tight whitespace-pre-wrap break-words break-all w-full">
 						{comment.message}
 					</div>
 				</>

--- a/viewer/src/components/superchat/superchat-form.tsx
+++ b/viewer/src/components/superchat/superchat-form.tsx
@@ -805,7 +805,7 @@ export function SuperchatForm({
 								disabled={isPending}
 								size="sm"
 							>
-								{isPending ? "送信中..." : "送信"}
+								{isPending ? "Sending..." : "Send"}
 							</Button>
 						</div>
 					</form>

--- a/viewer/src/components/superchat/superchat-form.tsx
+++ b/viewer/src/components/superchat/superchat-form.tsx
@@ -632,7 +632,7 @@ export function SuperchatForm({
 								render={({ field }) => (
 									<FormItem className="flex-grow mr-1">
 										<Input
-											placeholder="表示名"
+											placeholder="Display Name"
 											{...field}
 											className="text-base md:text-xs h-10 md:h-6"
 											onChange={(e) => {
@@ -718,7 +718,7 @@ export function SuperchatForm({
 											<FormItem className="flex-grow">
 												<Input
 													type="text"
-													placeholder="金額"
+													placeholder="Amount"
 													inputMode="decimal"
 													pattern="[0-9]*\.?[0-9]*"
 													{...field}
@@ -788,7 +788,7 @@ export function SuperchatForm({
 								render={({ field }) => (
 									<FormItem className="flex-grow">
 										<Textarea
-											placeholder="メッセージを入力..."
+											placeholder="Enter message..."
 											{...field}
 											className="text-base md:text-xs min-h-10 md:min-h-6 max-h-24 py-1 px-3 resize-none overflow-hidden"
 											style={{ height: "auto" }}

--- a/viewer/src/components/superchat/superchat-form.tsx
+++ b/viewer/src/components/superchat/superchat-form.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useMobileKeyboard } from "@/hooks/useMobileKeyboard";
+import { Send } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -801,11 +802,11 @@ export function SuperchatForm({
 							/>
 							<Button
 								type="submit"
-								className="ml-1 h-10 md:h-6"
+								className="ml-1 h-10 md:h-6 px-2"
 								disabled={isPending}
 								size="sm"
 							>
-								{isPending ? "Sending..." : "Send"}
+								<Send className="h-4 w-4" />
 							</Button>
 						</div>
 					</form>


### PR DESCRIPTION
## 概要
Issue #52で報告されたコメント重なり問題の根本修正を行い、併せてスーパーチャットフォームのUI改善を実装しました。仮想スクロールの高さ制限を削除することで、長文スーパーチャット後の通常コメントが重なる現象を解決しています。

## 変更内容
- `viewer/src/components/comments/comment-list.tsx`
    - estimateSize関数を実測ベースに簡略化（複雑な文字数計算を削除）
    - 仮想アイテムの固定高さ制限を削除してmeasureElementによる正確な実測を有効化
    - スーパーチャットと通常コメントの高さ制約を削除
    - 仮想スクロールのgapを2pxに設定して統一的な間隔制御

- `viewer/src/components/superchat/superchat-form.tsx`
    - 送信ボタンを紙飛行機アイコン（Lucide React Send）に変更
    - プレースホルダーテキストを英語に統一（Display Name, Amount, Enter message...）

- `viewer/package.json`
    - バージョンを0.4.2から0.4.3に更新

## 関連するIssue
Close #52

## 技術的改善点
- measureElementによる実測値で正確な高さ計算を実現
- 推定値と実測値の差分による累積誤差を解消
- TanStack Virtual の動的サイズ調整機能を適切に活用
- 国際化対応でUIの英語統一